### PR TITLE
ci: optimize pipeline — build once, fan out via Docker artifact, fan in

### DIFF
--- a/.bin/argsh
+++ b/.bin/argsh
@@ -232,7 +232,6 @@ coverage::builtin() {
   # Build coverage-instrumented .so inside Docker (rust:1-slim-bookworm) to ensure
   # glibc compatibility with the kcov/kcov test container (also Debian bookworm).
   # Mount sources at the same absolute path so llvm-cov finds them on the host.
-  # Share cargo registry cache to avoid re-downloading dependencies.
   # Install system lld and symlink it over rust-lld — both GNU ld and rust-lld
   # choke on colon-prefixed export_name symbols. System lld handles them.
   # See: https://github.com/rust-lang/rust/issues/38238

--- a/.bin/argsh
+++ b/.bin/argsh
@@ -233,9 +233,8 @@ coverage::builtin() {
   # glibc compatibility with the kcov/kcov test container (also Debian bookworm).
   # Mount sources at the same absolute path so llvm-cov finds them on the host.
   # Share cargo registry cache to avoid re-downloading dependencies.
-  # Install system lld — both GNU ld and rust-lld choke on the colon-prefixed
-  # export_name symbols. -Clinker-features=-lld disables Rust's bundled
-  # rust-lld so -fuse-ld=lld resolves to the system lld from apt.
+  # Install system lld and symlink it over rust-lld — both GNU ld and rust-lld
+  # choke on colon-prefixed export_name symbols. System lld handles them.
   # See: https://github.com/rust-lang/rust/issues/38238
   echo "Building with coverage instrumentation (via Docker)..."
   mkdir -p "${HOME}/.cargo/registry"
@@ -246,7 +245,8 @@ coverage::builtin() {
     -w "${PATH_BASE}/builtin" \
     rust:1-slim-bookworm \
     bash -c "apt-get update -qq && apt-get install -y -qq lld >/dev/null 2>&1 && \
-      RUSTFLAGS='-C instrument-coverage -Clinker-features=-lld -C link-arg=-fuse-ld=lld' \
+      ln -sf /usr/bin/ld.lld \"\$(rustc --print sysroot)/lib/rustlib/\$(rustc -vV | awk '/host/{print \$2}')/bin/gcc-ld/ld.lld\" && \
+      RUSTFLAGS='-C instrument-coverage -C link-arg=-fuse-ld=lld' \
       CARGO_PROFILE_RELEASE_STRIP=none \
       CARGO_PROFILE_RELEASE_LTO=false \
       CARGO_PROFILE_RELEASE_PANIC=unwind \

--- a/.bin/argsh
+++ b/.bin/argsh
@@ -250,7 +250,7 @@ coverage::builtin() {
       CARGO_PROFILE_RELEASE_LTO=false \
       CARGO_PROFILE_RELEASE_PANIC=unwind \
       cargo build --release && \
-      chown -R ${_uid} target/"
+      chown -R ${_uid} target/ /usr/local/cargo/registry/"
 
   rm -rf "${cov_dir}"
   mkdir -p "${cov_dir}"

--- a/.bin/argsh
+++ b/.bin/argsh
@@ -229,8 +229,8 @@ coverage::builtin() {
     rustup component add llvm-tools
   }
 
-  # Build coverage-instrumented .so inside Docker (rust:1-slim-bookworm) to ensure
-  # glibc compatibility with the kcov/kcov test container (also Debian bookworm).
+  # Build coverage-instrumented .so inside Docker (rust:1-slim-trixie) to ensure
+  # glibc compatibility with the argsh Docker image (also Debian trixie).
   # Mount sources at the same absolute path so llvm-cov finds them on the host.
   # Install system lld and symlink it over rust-lld — both GNU ld and rust-lld
   # choke on colon-prefixed export_name symbols. System lld handles them.
@@ -240,7 +240,7 @@ coverage::builtin() {
   docker run --rm \
     -v "${PATH_BASE}/builtin:${PATH_BASE}/builtin" \
     -w "${PATH_BASE}/builtin" \
-    rust:1-slim-bookworm \
+    rust:1-slim-trixie \
     bash -c "apt-get update -qq && apt-get install -y -qq lld >/dev/null 2>&1 && \
       ln -sf /usr/bin/ld.lld \"\$(rustc --print sysroot)/lib/rustlib/\$(rustc -vV | awk '/host/{print \$2}')/bin/gcc-ld/ld.lld\" && \
       RUSTFLAGS='-C instrument-coverage -C link-arg=-fuse-ld=lld' \

--- a/.bin/argsh
+++ b/.bin/argsh
@@ -237,11 +237,9 @@ coverage::builtin() {
   # choke on colon-prefixed export_name symbols. System lld handles them.
   # See: https://github.com/rust-lang/rust/issues/38238
   echo "Building with coverage instrumentation (via Docker)..."
-  mkdir -p "${HOME}/.cargo/registry"
   local _uid; _uid="$(id -u):$(id -g)"
   docker run --rm \
     -v "${PATH_BASE}/builtin:${PATH_BASE}/builtin" \
-    -v "${HOME}/.cargo/registry:/usr/local/cargo/registry" \
     -w "${PATH_BASE}/builtin" \
     rust:1-slim-bookworm \
     bash -c "apt-get update -qq && apt-get install -y -qq lld >/dev/null 2>&1 && \
@@ -251,7 +249,7 @@ coverage::builtin() {
       CARGO_PROFILE_RELEASE_LTO=false \
       CARGO_PROFILE_RELEASE_PANIC=unwind \
       cargo build --release && \
-      chown -R ${_uid} target/ /usr/local/cargo/registry/"
+      chown -R ${_uid} target/"
 
   rm -rf "${cov_dir}"
   mkdir -p "${cov_dir}"

--- a/.bin/argsh
+++ b/.bin/argsh
@@ -233,8 +233,10 @@ coverage::builtin() {
   # glibc compatibility with the kcov/kcov test container (also Debian bookworm).
   # Mount sources at the same absolute path so llvm-cov finds them on the host.
   # Share cargo registry cache to avoid re-downloading dependencies.
-  # Install system lld and override the rust-lld shim — Rust >=1.94 uses
-  # rust-lld by default, which chokes on colon-prefixed export_name symbols.
+  # Install system lld — both GNU ld and rust-lld choke on the colon-prefixed
+  # export_name symbols. -Clinker-features=-lld disables Rust's bundled
+  # rust-lld so -fuse-ld=lld resolves to the system lld from apt.
+  # See: https://github.com/rust-lang/rust/issues/38238
   echo "Building with coverage instrumentation (via Docker)..."
   mkdir -p "${HOME}/.cargo/registry"
   local _uid; _uid="$(id -u):$(id -g)"
@@ -244,8 +246,7 @@ coverage::builtin() {
     -w "${PATH_BASE}/builtin" \
     rust:1-slim-bookworm \
     bash -c "apt-get update -qq && apt-get install -y -qq lld >/dev/null 2>&1 && \
-      ln -sf /usr/bin/ld.lld \"\$(rustc --print sysroot)/lib/rustlib/\$(rustc -vV | awk '/host/{print \$2}')/bin/gcc-ld/ld.lld\" && \
-      RUSTFLAGS='-C instrument-coverage -C link-arg=-fuse-ld=lld' \
+      RUSTFLAGS='-C instrument-coverage -Clinker-features=-lld -C link-arg=-fuse-ld=lld' \
       CARGO_PROFILE_RELEASE_STRIP=none \
       CARGO_PROFILE_RELEASE_LTO=false \
       CARGO_PROFILE_RELEASE_PANIC=unwind \

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -98,16 +98,10 @@ jobs:
           path: .ci-bin
       - name: Install tools
         run: |
-          # bats — pinned to immutable commit SHAs for reproducibility
+          # bats — pinned to immutable commit SHA for reproducibility
           git clone https://github.com/bats-core/bats-core.git /tmp/bats
           git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
           sudo /tmp/bats/install.sh /usr/local
-          sudo git clone https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support
-          sudo git -C /usr/local/lib/bats-support checkout --detach 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1  # v0.3.0
-          sudo git clone https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert
-          sudo git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a  # v2.2.4
-          sudo git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
-          sudo git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60  # v0.4.0
           # argsh builtin .so
           sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
       - name: Direnv
@@ -195,16 +189,10 @@ jobs:
         run: |
           cp .ci-bin/minifier .bin/minifier
           chmod +x .bin/minifier
-          # bats (pinned SHAs)
+          # bats (pinned SHA)
           git clone https://github.com/bats-core/bats-core.git /tmp/bats
           git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
           sudo /tmp/bats/install.sh /usr/local
-          sudo git clone https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support
-          sudo git -C /usr/local/lib/bats-support checkout --detach 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1  # v0.3.0
-          sudo git clone https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert
-          sudo git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a  # v2.2.4
-          sudo git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
-          sudo git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60  # v0.4.0
           # argsh-lint + .so + verify shellcheck
           chmod +x .ci-bin/argsh-lint
           sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -99,9 +99,11 @@ jobs:
           path: .ci-bin
       - name: Install tools
         run: |
-          # bats — pinned to immutable commit SHA for reproducibility
-          git clone https://github.com/bats-core/bats-core.git /tmp/bats
-          git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
+          # bats — shallow fetch of pinned commit SHA for reproducibility
+          git init /tmp/bats
+          git -C /tmp/bats remote add origin https://github.com/bats-core/bats-core.git
+          git -C /tmp/bats fetch --depth 1 origin 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
+          git -C /tmp/bats checkout --detach FETCH_HEAD
           sudo /tmp/bats/install.sh /usr/local
           # argsh builtin .so
           sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -123,7 +123,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: gunzip -c /tmp/ci-image.tar.gz | docker load
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Test (pure bash)
         run: |
           docker run --rm \
@@ -152,7 +152,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: gunzip -c /tmp/ci-image.tar.gz | docker load
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Lint
         run: |
           docker run --rm \
@@ -203,7 +203,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: gunzip -c /tmp/ci-image.tar.gz | docker load
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Minify
         run: |
           docker run --rm \
@@ -382,7 +382,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: gunzip -c /tmp/ci-image.tar.gz | docker load
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Smoke test
         run: |
           docker run --rm \

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -16,6 +16,7 @@ on:
       - 'minifier/**'
       - 'shdoc/**'
       - 'crates/**'
+      - 'Dockerfile'
       - '.envrc'
 
 concurrency:
@@ -29,161 +30,36 @@ defaults:
 permissions: read-all
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Lint
-        run: argsh lint
-      - name: Test
-        run: argsh test
-      - name: Extract artifacts from Docker
-        run: |
-          mkdir -p builtin/target/release minifier/target/release shdoc/target/release
-          docker run --rm --entrypoint cat ghcr.io/arg-sh/argsh:latest /usr/local/lib/argsh.so > builtin/target/release/libargsh.so
-          docker run --rm --entrypoint cat ghcr.io/arg-sh/argsh:latest /usr/local/bin/minifier > minifier/target/release/minifier
-          docker run --rm --entrypoint cat ghcr.io/arg-sh/argsh:latest /usr/local/bin/shdoc > shdoc/target/release/shdoc
-          chmod +x minifier/target/release/minifier shdoc/target/release/shdoc
-      - name: Upload builtin library
-        uses: actions/upload-artifact@v7
-        with:
-          name: argsh-builtin-so
-          if-no-files-found: error
-          retention-days: 7
-          path: builtin/target/release/libargsh.so
-      - name: Upload minifier binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: minifier-bin
-          if-no-files-found: error
-          retention-days: 7
-          path: minifier/target/release/minifier
-      - name: Upload shdoc binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: shdoc-bin
-          if-no-files-found: error
-          retention-days: 7
-          path: shdoc/target/release/shdoc
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Coverage
-        run: argsh coverage builtin
-      - name: Is insync
-        run: |
-          git diff --exit-code \
-            --ignore-matching-lines '^  "date":' \
-            -- builtin/coverage.json
-
-  minifier-coverage:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Coverage
-        run: argsh coverage minifier
-      - name: Is insync
-        run: |
-          git diff --exit-code \
-            --ignore-matching-lines '^  "date":' \
-            -- minifier/coverage.json
-
-  shdoc-coverage:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Coverage
-        run: argsh coverage shdoc
-      - name: Is insync
-        run: |
-          git diff --exit-code \
-            --ignore-matching-lines '^  "date":' \
-            -- shdoc/coverage.json
-
-  lsp-coverage:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Coverage
-        run: argsh coverage lsp
-      - name: Is insync
-        run: |
-          git diff --exit-code \
-            --ignore-matching-lines '^  "date":' \
-            -- crates/argsh-lsp/coverage.json
-
-  minify:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Download minifier binary
-        uses: actions/download-artifact@v8
-        with:
-          name: minifier-bin
-          path: .bin
-      - name: Make minifier executable
-        run: chmod +x .bin/minifier
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Build
-        run: |
-          argsh minify
-      - name: Lint
-        run: |
-          argsh lint -m
-      - name: Test
-        run: |
-          argsh test -m
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: argsh
-          if-no-files-found: error
-          retention-days: 7
-          path: |
-            argsh.min.sh
-
-  build-binaries:
-    runs-on: ubuntu-latest
+  # ═══════════════════════════════════════════════════════════════════════
+  # Stage 1: BUILD — compile all Rust crates once per architecture.
+  # Everything else fans out from here.
+  # ═══════════════════════════════════════════════════════════════════════
+  build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build ${{ matrix.arch }} binaries
-        run: |
-          docker buildx build --platform linux/${{ matrix.arch }} \
-            --target artifacts \
-            --output type=local,dest=out .
-          chmod +x out/minifier out/shdoc
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/${{ matrix.arch }}
+          target: artifacts
+          outputs: type=local,dest=out
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
+      - name: Make executables
+        run: chmod +x out/minifier out/shdoc out/argsh-lsp out/argsh-lint 2>/dev/null || true
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -192,9 +68,142 @@ jobs:
           retention-days: 7
           path: out/
 
+  # ═══════════════════════════════════════════════════════════════════════
+  # Stage 2: FAN OUT — test, lint, coverage, minify run in parallel.
+  # All download pre-built binaries from the build stage.
+  # ═══════════════════════════════════════════════════════════════════════
+
+  # ---------------------------------------------------------------------------
+  # Test — run bats in both modes (pure-bash + native builtins).
+  # Downloads .so from build to test the current branch's builtin, not a stale
+  # published image.
+  # ---------------------------------------------------------------------------
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: binaries-linux-amd64
+          path: .ci-bin
+      - name: Install tools
+        run: |
+          # bats
+          git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git /tmp/bats
+          sudo /tmp/bats/install.sh /usr/local
+          sudo git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support
+          sudo git clone --depth 1 --branch v2.2.4 https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert
+          sudo git clone --depth 1 --branch v0.4.0 https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
+          # argsh builtin .so
+          sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
+      - name: Direnv
+        uses: HatsuneMiku3939/direnv-action@v1
+      - name: Test (pure bash)
+        run: argsh test
+      - name: Test (native builtins)
+        env:
+          ARGSH_BUILTIN_TEST: "1"
+          ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
+        run: argsh test
+
+  # ---------------------------------------------------------------------------
+  # Lint — shellcheck + argsh-lint on all shell files.
+  # ---------------------------------------------------------------------------
+  lint:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: binaries-linux-amd64
+          path: .ci-bin
+      - name: Install argsh-lint
+        run: |
+          chmod +x .ci-bin/argsh-lint
+          sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
+      - name: Direnv
+        uses: HatsuneMiku3939/direnv-action@v1
+      - name: Lint
+        run: argsh lint
+
+  # ---------------------------------------------------------------------------
+  # Coverage — all 4 Rust crates in one job.
+  # ---------------------------------------------------------------------------
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Direnv
+        uses: HatsuneMiku3939/direnv-action@v1
+      - name: Builtin coverage
+        run: argsh coverage builtin
+      - name: Minifier coverage
+        run: argsh coverage minifier
+      - name: Shdoc coverage
+        run: argsh coverage shdoc
+      - name: LSP coverage
+        run: argsh coverage lsp
+      - name: Verify coverage files are in sync
+        run: |
+          git diff --exit-code \
+            --ignore-matching-lines '^  "date":' \
+            -- builtin/coverage.json \
+               minifier/coverage.json \
+               shdoc/coverage.json \
+               crates/argsh-lsp/coverage.json
+
+  # ---------------------------------------------------------------------------
+  # Minify — produce argsh.min.sh using the freshly-built minifier.
+  # ---------------------------------------------------------------------------
+  minify:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Download minifier
+        uses: actions/download-artifact@v8
+        with:
+          name: binaries-linux-amd64
+          path: .ci-bin
+      - name: Install minifier
+        run: |
+          cp .ci-bin/minifier .bin/minifier
+          chmod +x .bin/minifier
+      - name: Direnv
+        uses: HatsuneMiku3939/direnv-action@v1
+      - name: Minify
+        run: argsh minify
+      - name: Lint minified
+        run: argsh lint -m
+      - name: Test minified
+        run: argsh test -m
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: argsh
+          if-no-files-found: error
+          retention-days: 7
+          path: argsh.min.sh
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # Stage 3: FAN IN — assemble final outputs from stage 1+2 artifacts.
+  # ═══════════════════════════════════════════════════════════════════════
+
+  # ---------------------------------------------------------------------------
+  # Minify-so — concatenate argsh.min.sh + .so → self-contained binary.
+  # ---------------------------------------------------------------------------
   minify-so:
     runs-on: ubuntu-latest
-    needs: [minify, build-binaries]
+    needs: [minify]
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -211,7 +220,6 @@ jobs:
           path: .
       - name: Compose argsh-so
         run: |
-          # Build script portion with appended-binary loader
           {
             head -3 argsh.min.sh
             echo '# ── Appended native builtins ─────────────────────────────────────────'
@@ -254,7 +262,6 @@ jobs:
           EXITEOF
           } > script-part.sh
 
-          # Stabilize byte offset (loop until size converges)
           converged=0
           prev_sz=0
           for i in $(seq 1 10); do
@@ -268,7 +275,6 @@ jobs:
           done
           [ "${converged}" -eq 1 ] || { echo "Failed to stabilize ARGSH_PAYLOAD_OFFSET" >&2; exit 1; }
 
-          # Concatenate script + raw .so binary
           cat script-part.sh binaries/libargsh.so > argsh-so
           chmod +x argsh-so
           rm script-part.sh
@@ -291,9 +297,13 @@ jobs:
           name: argsh-so-linux-${{ matrix.arch }}
           if-no-files-found: error
           retention-days: 7
-          path: |
-            argsh-so
+          path: argsh-so
 
+  # ---------------------------------------------------------------------------
+  # Docker — assemble final image reusing cached Rust layers from the build job.
+  # The Rust build stages are cache hits (populated by the build job via GHA
+  # cache), so only the final assembly layers run fresh.
+  # ---------------------------------------------------------------------------
   docker:
     runs-on: ubuntu-latest
     needs: [minify]
@@ -303,15 +313,13 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
-      - name: Download executables
+      - name: Download argsh.min.sh
         uses: actions/download-artifact@v8
         with:
-          pattern: argsh
-          merge-multiple: true
+          name: argsh
           path: .
-      - name: Executable
-        run: |
-          chmod +x argsh.min.sh
+      - name: Prepare
+        run: chmod +x argsh.min.sh
       - name: Docker metadata
         uses: docker/metadata-action@v5
         id: metadata
@@ -339,6 +347,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: |
+            type=gha,scope=build-amd64
+            type=gha,scope=build-arm64
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # Stage 4: RELEASE (tag only) — build native LSP/lint binaries for
+  # macOS/Linux, package VSCode extension, publish everything.
+  # ═══════════════════════════════════════════════════════════════════════
 
   build-lsp:
     name: Build argsh-lsp/lint (${{ matrix.target }})
@@ -438,7 +454,7 @@ jobs:
       contents: write
       pull-requests: write
     environment: release
-    needs: [minify, minify-so, build-binaries, build-lsp, docker, package-vsix]
+    needs: [minify, minify-so, build-lsp, docker, package-vsix]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Clone repository
@@ -458,8 +474,6 @@ jobs:
         with:
           pattern: argsh-so-linux-*
           path: artifacts
-      # download-artifact patterns use glob, not brace expansion — download
-      # the two binaries in separate steps, merging into the same dir.
       - name: Download all LSP binaries
         uses: actions/download-artifact@v8
         with:
@@ -482,11 +496,9 @@ jobs:
         run: |
           mkdir -p release
 
-          # argsh (arch-independent shell script)
           cp artifacts/argsh.min.sh release/argsh
           chmod +x release/argsh
 
-          # Per-architecture assets
           for arch in amd64 arm64; do
             cp "artifacts/binaries-linux-${arch}/libargsh.so" "release/argsh-linux-${arch}.so"
             cp "artifacts/binaries-linux-${arch}/minifier"    "release/minifier-linux-${arch}"
@@ -495,14 +507,12 @@ jobs:
             chmod +x "release/minifier-linux-${arch}" "release/shdoc-linux-${arch}" "release/argsh-so-linux-${arch}"
           done
 
-          # LSP server and CLI linter — per-platform (linux + darwin, x64 + arm64)
           for p in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             cp "artifacts/lsp/argsh-lsp-${p}"  "release/argsh-lsp-${p}"
             cp "artifacts/lsp/argsh-lint-${p}" "release/argsh-lint-${p}"
             chmod +x "release/argsh-lsp-${p}" "release/argsh-lint-${p}"
           done
 
-          # VSCode extension bundles
           cp artifacts/vsix/*.vsix release/
 
           cd release
@@ -512,7 +522,6 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create or update release (idempotent for re-runs)
           gh release create "${TAG_NAME}" --draft --title "argsh ${TAG_NAME}" --generate-notes 2>/dev/null \
             || gh release edit "${TAG_NAME}" --draft --title "argsh ${TAG_NAME}"
           gh release upload "${TAG_NAME}" --clobber release/*
@@ -525,7 +534,6 @@ jobs:
           cp artifacts/argsh.min.sh argsh.min.sh
           git add argsh.min.sh
           git commit -m "${title}"
-          # Force-push branch (handles re-runs where branch already exists)
           git push --force origin "HEAD:refs/heads/${branch}"
           gh pr create --title "${title}" --body "" --head "${branch}" 2>/dev/null \
             || echo "PR already exists for ${branch}"

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -192,9 +192,11 @@ jobs:
         run: |
           cp .ci-bin/minifier .bin/minifier
           chmod +x .bin/minifier
-          # bats (pinned SHA)
-          git clone https://github.com/bats-core/bats-core.git /tmp/bats
-          git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
+          # bats — shallow fetch of pinned commit SHA for reproducibility
+          git init /tmp/bats
+          git -C /tmp/bats remote add origin https://github.com/bats-core/bats-core.git
+          git -C /tmp/bats fetch --depth 1 origin 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
+          git -C /tmp/bats checkout --detach FETCH_HEAD
           sudo /tmp/bats/install.sh /usr/local
           # argsh-lint + .so + verify shellcheck
           chmod +x .ci-bin/argsh-lint

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -52,9 +52,9 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build ${{ matrix.arch }} binaries
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/${{ matrix.arch }}
@@ -82,7 +82,7 @@ jobs:
       # so fan-out jobs can docker-load it for test/lint/minify (~52MB compressed).
       - name: Build CI image
         if: matrix.arch == 'amd64'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -358,7 +358,7 @@ jobs:
       - name: Prepare
         run: chmod +x argsh.min.sh
       - name: Docker metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         id: metadata
         with:
           images: ghcr.io/${{ github.repository }}
@@ -366,11 +366,11 @@ jobs:
             && format('type=match,pattern=v(.*),group=1,value={0}', github.ref_name)
             || 'type=sha,format=long' }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -391,7 +391,7 @@ jobs:
       # Multi-platform build + push with the final argsh.min.sh embedded.
       # Rust stages are cache hits from the build job.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -123,7 +123,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: docker load < /tmp/ci-image.tar.gz
+        run: gunzip -c /tmp/ci-image.tar.gz | docker load
       - name: Test (pure bash)
         run: |
           docker run --rm \
@@ -152,7 +152,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: docker load < /tmp/ci-image.tar.gz
+        run: gunzip -c /tmp/ci-image.tar.gz | docker load
       - name: Lint
         run: |
           docker run --rm \
@@ -203,7 +203,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: docker load < /tmp/ci-image.tar.gz
+        run: gunzip -c /tmp/ci-image.tar.gz | docker load
       - name: Minify
         run: |
           docker run --rm \
@@ -382,7 +382,7 @@ jobs:
           name: ci-image
           path: /tmp
       - name: Import CI image
-        run: docker load < /tmp/ci-image.tar.gz
+        run: gunzip -c /tmp/ci-image.tar.gz | docker load
       - name: Smoke test
         run: |
           docker run --rm \

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -142,10 +142,10 @@ jobs:
         run: |
           chmod +x .ci-bin/argsh-lint
           sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
       - name: Lint
-        run: argsh lint libraries
+        env:
+          ARGSH_SOURCE: argsh
+        run: bash argsh.min.sh lint libraries
 
   # ---------------------------------------------------------------------------
   # Coverage — all 4 Rust crates in one job.

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -116,13 +116,13 @@ jobs:
         env:
           ARGSH_PURE_BASH_TEST: "1"
           ARGSH_SOURCE: argsh
-        run: bats libraries/ .docker/test/
+        run: bats libraries/
       - name: Test (native builtins)
         env:
           ARGSH_BUILTIN_TEST: "1"
           ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
           ARGSH_SOURCE: argsh
-        run: bats libraries/ .docker/test/
+        run: bats libraries/
 
   # ---------------------------------------------------------------------------
   # Lint — shellcheck + argsh-lint on all shell files.

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -29,10 +29,14 @@ defaults:
 
 permissions: read-all
 
+env:
+  CI_IMAGE: argsh-ci:local
+
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
   # Stage 1: BUILD — compile all Rust crates once per architecture.
-  # Everything else fans out from here.
+  # The amd64 job also builds the Docker image and saves it as an artifact
+  # so fan-out jobs can docker-load it for test/lint/minify.
   # ═══════════════════════════════════════════════════════════════════════
   build:
     name: Build (${{ matrix.arch }})
@@ -74,17 +78,38 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           path: out/
+      # amd64 only: build the full Docker image and save it as an artifact
+      # so fan-out jobs can docker-load it for test/lint/minify (~52MB compressed).
+      - name: Build CI image
+        if: matrix.arch == 'amd64'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          provenance: false
+          platforms: linux/amd64
+          tags: ${{ env.CI_IMAGE }}
+          cache-from: type=gha,scope=build-amd64
+      - name: Save CI image
+        if: matrix.arch == 'amd64'
+        run: docker save ${{ env.CI_IMAGE }} | gzip > /tmp/ci-image.tar.gz
+      - name: Upload CI image
+        if: matrix.arch == 'amd64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-image
+          if-no-files-found: error
+          retention-days: 1
+          path: /tmp/ci-image.tar.gz
 
   # ═══════════════════════════════════════════════════════════════════════
   # Stage 2: FAN OUT — test, lint, coverage, minify run in parallel.
-  # Jobs download build artifacts from Stage 1 or rebuild as needed
-  # (e.g. coverage uses instrumentation-specific builds).
+  # test/lint/minify run inside the freshly-built CI image.
+  # Coverage rebuilds with instrumentation (separate Docker containers).
   # ═══════════════════════════════════════════════════════════════════════
 
   # ---------------------------------------------------------------------------
   # Test — run bats in both modes (pure-bash + native builtins).
-  # Downloads .so from build to test the current branch's builtin, not a stale
-  # published image.
   # ---------------------------------------------------------------------------
   test:
     runs-on: ubuntu-latest
@@ -92,34 +117,25 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
-      - name: Download binaries
+      - name: Load CI image
         uses: actions/download-artifact@v8
         with:
-          name: binaries-linux-amd64
-          path: .ci-bin
-      - name: Install tools
-        run: |
-          # bats — shallow fetch of pinned commit SHA for reproducibility
-          git init /tmp/bats
-          git -C /tmp/bats remote add origin https://github.com/bats-core/bats-core.git
-          git -C /tmp/bats fetch --depth 1 origin 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
-          git -C /tmp/bats checkout --detach FETCH_HEAD
-          sudo /tmp/bats/install.sh /usr/local
-          # argsh builtin .so
-          sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
+          name: ci-image
+          path: /tmp
+      - name: Import CI image
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Test (pure bash)
-        env:
-          ARGSH_PURE_BASH_TEST: "1"
-          ARGSH_SOURCE: argsh
-        run: bats libraries/
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -e ARGSH_PURE_BASH_TEST=1 \
+            ${{ env.CI_IMAGE }} test libraries/
       - name: Test (native builtins)
-        env:
-          ARGSH_BUILTIN_TEST: "1"
-          ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
-          ARGSH_SOURCE: argsh
-        run: bats libraries/
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -e ARGSH_BUILTIN_TEST=1 \
+            ${{ env.CI_IMAGE }} test libraries/
 
   # ---------------------------------------------------------------------------
   # Lint — shellcheck + argsh-lint on the argsh libraries.
@@ -130,21 +146,18 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
-      - name: Download binaries
+      - name: Load CI image
         uses: actions/download-artifact@v8
         with:
-          name: binaries-linux-amd64
-          path: .ci-bin
-      - name: Install tools
-        run: |
-          chmod +x .ci-bin/argsh-lint
-          sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
-          # Verify shellcheck is available (pre-installed on ubuntu-latest).
-          shellcheck --version
+          name: ci-image
+          path: /tmp
+      - name: Import CI image
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Lint
-        env:
-          ARGSH_SOURCE: argsh
-        run: bash argsh.min.sh lint libraries
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            ${{ env.CI_IMAGE }} lint libraries/
 
   # ---------------------------------------------------------------------------
   # Coverage — all 4 Rust crates in one job.
@@ -176,6 +189,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Minify — produce argsh.min.sh using the freshly-built minifier.
+  # Uses the CI image for minify, lint, and test — same container, same tools.
   # ---------------------------------------------------------------------------
   minify:
     runs-on: ubuntu-latest
@@ -183,44 +197,32 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
-      - name: Download minifier
+      - name: Load CI image
         uses: actions/download-artifact@v8
         with:
-          name: binaries-linux-amd64
-          path: .ci-bin
-      - name: Install tools
-        run: |
-          cp .ci-bin/minifier .bin/minifier
-          chmod +x .bin/minifier
-          # bats — shallow fetch of pinned commit SHA for reproducibility
-          git init /tmp/bats
-          git -C /tmp/bats remote add origin https://github.com/bats-core/bats-core.git
-          git -C /tmp/bats fetch --depth 1 origin 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
-          git -C /tmp/bats checkout --detach FETCH_HEAD
-          sudo /tmp/bats/install.sh /usr/local
-          # argsh-lint + .so + verify shellcheck
-          chmod +x .ci-bin/argsh-lint
-          sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
-          sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
-          shellcheck --version
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
+          name: ci-image
+          path: /tmp
+      - name: Import CI image
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Minify
-        env:
-          GIT_COMMIT_SHA: ${{ github.sha }}
-          GIT_VERSION: ${{ github.ref_name }}
-        run: argsh minify
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -e GIT_COMMIT_SHA=${{ github.sha }} \
+            -e GIT_VERSION=${{ github.ref_name }} \
+            ${{ env.CI_IMAGE }} minify
       - name: Lint minified
-        env:
-          ARGSH_SOURCE: argsh
-        run: bash argsh.min.sh lint argsh.min.sh
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            ${{ env.CI_IMAGE }} lint argsh.min.sh
       - name: Test minified
-        env:
-          BATS_LOAD: argsh.min.sh
-          ARGSH_SOURCE: argsh
-          ARGSH_BUILTIN_TEST: "1"
-          ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
-        run: bats libraries/
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -e BATS_LOAD=argsh.min.sh \
+            -e ARGSH_BUILTIN_TEST=1 \
+            ${{ env.CI_IMAGE }} test libraries/
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -373,21 +375,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # Build amd64 image locally for smoke testing.
-      - name: Build Docker image (amd64, local)
-        uses: docker/build-push-action@v5
+      # Smoke test: load the CI image and run entrypoint tests inside it.
+      - name: Load CI image
+        uses: actions/download-artifact@v8
         with:
-          context: .
-          load: true
-          provenance: false
-          platforms: linux/amd64
-          tags: argsh-test:local
-          cache-from: type=gha,scope=build-amd64
-      # Run the entrypoint tests inside the freshly-built image.
+          name: ci-image
+          path: /tmp
+      - name: Import CI image
+        run: docker load < /tmp/ci-image.tar.gz
       - name: Smoke test
         run: |
-          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace argsh-test:local test libraries/ .docker/test/
-      # Multi-platform build + push (tag only). Rust stages are cache hits.
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            ${{ env.CI_IMAGE }} test libraries/ .docker/test/
+      # Multi-platform build + push with the final argsh.min.sh embedded.
+      # Rust stages are cache hits from the build job.
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -206,6 +206,9 @@ jobs:
       - name: Direnv
         uses: HatsuneMiku3939/direnv-action@v1
       - name: Minify
+        env:
+          GIT_COMMIT_SHA: ${{ github.sha }}
+          GIT_VERSION: ${{ github.ref_name }}
         run: argsh minify
       - name: Lint minified
         env:

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -115,12 +115,14 @@ jobs:
       - name: Test (pure bash)
         env:
           ARGSH_PURE_BASH_TEST: "1"
-        run: argsh test
+          ARGSH_SOURCE: argsh
+        run: bats libraries/ .docker/test/
       - name: Test (native builtins)
         env:
           ARGSH_BUILTIN_TEST: "1"
           ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
-        run: argsh test
+          ARGSH_SOURCE: argsh
+        run: bats libraries/ .docker/test/
 
   # ---------------------------------------------------------------------------
   # Lint — shellcheck + argsh-lint on all shell files.

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -58,8 +58,15 @@ jobs:
           outputs: type=local,dest=out
           cache-from: type=gha,scope=build-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
-      - name: Make executables
-        run: chmod +x out/minifier out/shdoc out/argsh-lsp out/argsh-lint 2>/dev/null || true
+      - name: Validate and make executables
+        run: |
+          for f in out/minifier out/shdoc out/libargsh.so out/argsh-lsp out/argsh-lint; do
+            if [[ ! -f "${f}" ]]; then
+              echo "Missing expected artifact: ${f}" >&2
+              exit 1
+            fi
+          done
+          chmod +x out/minifier out/shdoc out/argsh-lsp out/argsh-lint
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -91,17 +98,23 @@ jobs:
           path: .ci-bin
       - name: Install tools
         run: |
-          # bats
-          git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git /tmp/bats
+          # bats — pinned to immutable commit SHAs for reproducibility
+          git clone https://github.com/bats-core/bats-core.git /tmp/bats
+          git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
           sudo /tmp/bats/install.sh /usr/local
-          sudo git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support
-          sudo git clone --depth 1 --branch v2.2.4 https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert
-          sudo git clone --depth 1 --branch v0.4.0 https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
+          sudo git clone https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support
+          sudo git -C /usr/local/lib/bats-support checkout --detach 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1  # v0.3.0
+          sudo git clone https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert
+          sudo git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a  # v2.2.4
+          sudo git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
+          sudo git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60  # v0.4.0
           # argsh builtin .so
           sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
       - name: Direnv
         uses: HatsuneMiku3939/direnv-action@v1
       - name: Test (pure bash)
+        env:
+          ARGSH_PURE_BASH_TEST: "1"
         run: argsh test
       - name: Test (native builtins)
         env:

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -189,18 +189,38 @@ jobs:
         with:
           name: binaries-linux-amd64
           path: .ci-bin
-      - name: Install minifier
+      - name: Install tools
         run: |
           cp .ci-bin/minifier .bin/minifier
           chmod +x .bin/minifier
+          # bats (pinned SHAs)
+          git clone https://github.com/bats-core/bats-core.git /tmp/bats
+          git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87  # v1.13.0
+          sudo /tmp/bats/install.sh /usr/local
+          sudo git clone https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support
+          sudo git -C /usr/local/lib/bats-support checkout --detach 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1  # v0.3.0
+          sudo git clone https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert
+          sudo git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a  # v2.2.4
+          sudo git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
+          sudo git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60  # v0.4.0
+          # argsh-lint + .so
+          chmod +x .ci-bin/argsh-lint
+          sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
+          sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
       - name: Direnv
         uses: HatsuneMiku3939/direnv-action@v1
       - name: Minify
         run: argsh minify
       - name: Lint minified
-        run: argsh lint -m
+        env:
+          ARGSH_SOURCE: argsh
+        run: bash argsh.min.sh lint argsh.min.sh
       - name: Test minified
-        run: argsh test -m
+        env:
+          BATS_LOAD: argsh.min.sh
+          ARGSH_SOURCE: argsh
+          ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
+        run: bats libraries/
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -211,6 +211,7 @@ jobs:
         env:
           BATS_LOAD: argsh.min.sh
           ARGSH_SOURCE: argsh
+          ARGSH_BUILTIN_TEST: "1"
           ARGSH_BUILTIN_PATH: /usr/local/lib/argsh.so
         run: bats libraries/
       - name: Upload artifacts

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -138,10 +138,12 @@ jobs:
         with:
           name: binaries-linux-amd64
           path: .ci-bin
-      - name: Install argsh-lint
+      - name: Install tools
         run: |
           chmod +x .ci-bin/argsh-lint
           sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
+          # Verify shellcheck is available (pre-installed on ubuntu-latest).
+          shellcheck --version
       - name: Lint
         env:
           ARGSH_SOURCE: argsh
@@ -203,10 +205,11 @@ jobs:
           sudo git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a  # v2.2.4
           sudo git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file
           sudo git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60  # v0.4.0
-          # argsh-lint + .so
+          # argsh-lint + .so + verify shellcheck
           chmod +x .ci-bin/argsh-lint
           sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
           sudo cp .ci-bin/libargsh.so /usr/local/lib/argsh.so
+          shellcheck --version
       - name: Direnv
         uses: HatsuneMiku3939/direnv-action@v1
       - name: Minify
@@ -373,7 +376,22 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and release Docker image
+      # Build amd64 image locally for smoke testing.
+      - name: Build Docker image (amd64, local)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          provenance: false
+          platforms: linux/amd64
+          tags: argsh-test:local
+          cache-from: type=gha,scope=build-amd64
+      # Run the entrypoint tests inside the freshly-built image.
+      - name: Smoke test
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" argsh-test:local test libraries/ .docker/test/
+      # Multi-platform build + push (tag only). Rust stages are cache hits.
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -386,7 +386,7 @@ jobs:
       # Run the entrypoint tests inside the freshly-built image.
       - name: Smoke test
         run: |
-          docker run --rm -v "${{ github.workspace }}:/workspace" argsh-test:local test libraries/ .docker/test/
+          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace argsh-test:local test libraries/ .docker/test/
       # Multi-platform build + push (tag only). Rust stages are cache hits.
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -77,7 +77,8 @@ jobs:
 
   # ═══════════════════════════════════════════════════════════════════════
   # Stage 2: FAN OUT — test, lint, coverage, minify run in parallel.
-  # All download pre-built binaries from the build stage.
+  # Jobs download build artifacts from Stage 1 or rebuild as needed
+  # (e.g. coverage uses instrumentation-specific builds).
   # ═══════════════════════════════════════════════════════════════════════
 
   # ---------------------------------------------------------------------------
@@ -119,7 +120,7 @@ jobs:
         run: bats libraries/
 
   # ---------------------------------------------------------------------------
-  # Lint — shellcheck + argsh-lint on all shell files.
+  # Lint — shellcheck + argsh-lint on the argsh libraries.
   # ---------------------------------------------------------------------------
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -583,7 +583,7 @@ jobs:
 
           cp artifacts/argsh.min.sh argsh.min.sh
           git add argsh.min.sh
-          git commit -m "${title}"
+          git diff --cached --quiet || git commit -m "${title}"
           git push --force origin "HEAD:refs/heads/${branch}"
           gh pr create --title "${title}" --body "" --head "${branch}" 2>/dev/null \
             || echo "PR already exists for ${branch}"

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -138,24 +138,14 @@ jobs:
         with:
           name: binaries-linux-amd64
           path: .ci-bin
-      - name: Install tools
+      - name: Install argsh-lint
         run: |
           chmod +x .ci-bin/argsh-lint
           sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
-          # shellcheck is pre-installed on ubuntu-latest; verify it's available.
-          command -v shellcheck || { echo "shellcheck not found" >&2; exit 1; }
-      - name: Lint (shellcheck)
-        run: |
-          find libraries -name '*.sh' -o -name '*.bats' -o -name '*.bash' | sort | while read -r f; do
-            echo "shellcheck ${f}" >&2
-            shellcheck "${f}" || exit 1
-          done
-      - name: Lint (argsh-lint)
-        run: |
-          find libraries -name '*.sh' -o -name '*.bats' | sort | while read -r f; do
-            echo "argsh-lint ${f}" >&2
-            argsh-lint "${f}" || exit 1
-          done
+      - name: Direnv
+        uses: HatsuneMiku3939/direnv-action@v1
+      - name: Lint
+        run: argsh lint libraries
 
   # ---------------------------------------------------------------------------
   # Coverage — all 4 Rust crates in one job.

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -138,14 +138,24 @@ jobs:
         with:
           name: binaries-linux-amd64
           path: .ci-bin
-      - name: Install argsh-lint
+      - name: Install tools
         run: |
           chmod +x .ci-bin/argsh-lint
           sudo cp .ci-bin/argsh-lint /usr/local/bin/argsh-lint
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Lint
-        run: argsh lint
+          # shellcheck is pre-installed on ubuntu-latest; verify it's available.
+          command -v shellcheck || { echo "shellcheck not found" >&2; exit 1; }
+      - name: Lint (shellcheck)
+        run: |
+          find libraries -name '*.sh' -o -name '*.bats' -o -name '*.bash' | sort | while read -r f; do
+            echo "shellcheck ${f}" >&2
+            shellcheck "${f}" || exit 1
+          done
+      - name: Lint (argsh-lint)
+        run: |
+          find libraries -name '*.sh' -o -name '*.bats' | sort | while read -r f; do
+            echo "argsh-lint ${f}" >&2
+            argsh-lint "${f}" || exit 1
+          done
 
   # ---------------------------------------------------------------------------
   # Coverage — all 4 Rust crates in one job.

--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -210,7 +210,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" -w /workspace \
             -e GIT_COMMIT_SHA=${{ github.sha }} \
             -e GIT_VERSION=${{ github.ref_name }} \
-            ${{ env.CI_IMAGE }} minify
+            ${{ env.CI_IMAGE }} minify libraries -t argsh.min.tmpl -o argsh.min.sh
       - name: Lint minified
         run: |
           docker run --rm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-l
 
 FROM debian:bookworm-slim
 
-# kcov — bash script coverage (binary + runtime deps from the kcov image)
+# kcov — bash script coverage (binary copied from kcov image; runtime deps
+# installed via apt below to keep them up-to-date with the base image)
 COPY --from=kcov/kcov /usr/local/bin/kcov /usr/local/bin/kcov
 
 # test — bats-core + standard helper libraries (support, assert, file)

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,12 @@ COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-l
 
 FROM debian:trixie-slim
 
-# kcov — bash script coverage (binary copied from kcov image; runtime deps
-# installed via apt below to keep them up-to-date with the base image)
-COPY --from=kcov/kcov /usr/local/bin/kcov /usr/local/bin/kcov
+# kcov — bash script coverage (binary copied from pinned kcov image;
+# runtime deps installed via apt below to keep them up-to-date with the base)
+COPY --from=kcov/kcov@sha256:5c61bd03d2b7f4fa74131b18e4e80356a92a7517872b5b9a505022c38cd6d123 /usr/local/bin/kcov /usr/local/bin/kcov
 
 # test — bats-core + standard helper libraries (support, assert, file)
-# Pinned to latest release tags; shallow clones for faster builds.
+# Pinned to immutable commit SHAs for reproducibility.
 RUN set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -73,11 +73,15 @@ RUN set -eux \
       libcurl4 libdw1 libelf1 zlib1g \
       # envsubst
       gettext-base \
-  && git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git /tmp/bats \
+  && git clone https://github.com/bats-core/bats-core.git /tmp/bats \
+  && git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87 \
   && /tmp/bats/install.sh /usr/local \
-  && git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support \
-  && git clone --depth 1 --branch v2.2.4 https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert \
-  && git clone --depth 1 --branch v0.4.0 https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file \
+  && git clone https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support \
+  && git -C /usr/local/lib/bats-support checkout --detach 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1 \
+  && git clone https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert \
+  && git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a \
+  && git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file \
+  && git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60 \
   && rm -rf /tmp/bats \
       /usr/local/lib/bats-support/.git \
       /usr/local/lib/bats-assert/.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,25 +57,32 @@ COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-l
 
 # ── Final image ──────────────────────────────────────────────────────────
 
-# coverage
-FROM kcov/kcov
+FROM debian:bookworm-slim
+
+# kcov — bash script coverage (binary + runtime deps from the kcov image)
+COPY --from=kcov/kcov /usr/local/bin/kcov /usr/local/bin/kcov
 
 # test — bats-core + standard helper libraries (support, assert, file)
 # Pinned to latest release tags; shallow clones for faster builds.
 RUN set -eux \
-  && apt update \
-  && apt install -y git \
-  && git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git \
-  && cd bats-core && ./install.sh /usr/local && cd .. \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+      git bash ca-certificates curl \
+      # kcov runtime dependencies
+      libcurl4 libdw1 libelf1 zlib1g \
+      # envsubst
+      gettext-base \
+  && git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git /tmp/bats \
+  && /tmp/bats/install.sh /usr/local \
   && git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support \
   && git clone --depth 1 --branch v2.2.4 https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert \
   && git clone --depth 1 --branch v0.4.0 https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file \
-  && rm -rf bats-core \
+  && rm -rf /tmp/bats \
       /usr/local/lib/bats-support/.git \
       /usr/local/lib/bats-assert/.git \
       /usr/local/lib/bats-file/.git \
-  && apt remove -y git \
-  && apt autoremove -y \
+  && apt-get remove -y git \
+  && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
 # lint
@@ -84,10 +91,6 @@ COPY --from=koalaman/shellcheck:stable /bin/shellcheck /usr/local/bin/shellcheck
 # tools
 COPY --from=ghcr.io/jqlang/jq:1.8.1 /jq /usr/local/bin/jq
 COPY --from=mikefarah/yq:4.52.5 /usr/bin/yq /usr/local/bin/yq
-RUN set -eux \
-  && apt update \
-  && apt install -y gettext-base \
-  && rm -rf /var/lib/apt/lists/*
 
 # argsh itself
 COPY --from=minifier-build /build/target/release/minifier /usr/local/bin/minifier

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@
 # ── Rust build stages ────────────────────────────────────────────────────
 
 # minify — build Rust minifier
-FROM rust:1-slim-bookworm AS minifier-build
+FROM rust:1-slim-trixie AS minifier-build
 WORKDIR /build
 COPY minifier/ .
 RUN cargo build --release
 
 # shdoc — build Rust documentation generator
-FROM rust:1-slim-bookworm AS shdoc-build
+FROM rust:1-slim-trixie AS shdoc-build
 WORKDIR /build
 COPY shdoc/ .
 RUN cargo build --release
@@ -29,7 +29,7 @@ RUN cargo build --release
 # -fuse-ld=lld resolves to system lld on all architectures.
 # (-Clinker-features=-lld would be cleaner but is only stable on x86_64.)
 # See: https://github.com/rust-lang/rust/issues/38238
-FROM rust:1-slim-bookworm AS builtin-build
+FROM rust:1-slim-trixie AS builtin-build
 RUN apt-get update && apt-get install -y --no-install-recommends lld && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
 ARG RUSTFLAGS
@@ -42,7 +42,7 @@ COPY builtin/ .
 RUN cargo build --release
 
 # argsh-lsp / argsh-lint — LSP server + CLI linter (share the same crate).
-FROM rust:1-slim-bookworm AS lsp-build
+FROM rust:1-slim-trixie AS lsp-build
 WORKDIR /build
 COPY crates/ crates/
 RUN cargo build --release --manifest-path crates/argsh-lsp/Cargo.toml --bins
@@ -57,7 +57,7 @@ COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-l
 
 # ── Final image ──────────────────────────────────────────────────────────
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # kcov — bash script coverage (binary copied from kcov image; runtime deps
 # installed via apt below to keep them up-to-date with the base image)
@@ -91,7 +91,7 @@ COPY --from=koalaman/shellcheck:stable /bin/shellcheck /usr/local/bin/shellcheck
 
 # tools
 COPY --from=ghcr.io/jqlang/jq:1.8.1 /jq /usr/local/bin/jq
-COPY --from=mikefarah/yq:4.52.5 /usr/bin/yq /usr/local/bin/yq
+COPY --from=mikefarah/yq:4.53.2 /usr/bin/yq /usr/local/bin/yq
 
 # argsh itself
 COPY --from=minifier-build /build/target/release/minifier /usr/local/bin/minifier

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cargo build --release
 # builtin — build Rust loadable builtins
 # System lld (from apt) is required because export_name attributes contain
 # colons (e.g. ":args_struct") which cause "syntax error in VERSION script"
-# with both GNU ld and rust-lld. System lld (Debian LLD 14) handles them.
+# with both GNU ld and rust-lld. The system lld (from apt) handles them.
 # We symlink system lld over the rust-lld shim in gcc-ld/ so that
 # -fuse-ld=lld resolves to system lld on all architectures.
 # (-Clinker-features=-lld would be cleaner but is only stable on x86_64.)
@@ -73,15 +73,20 @@ RUN set -eux \
       libcurl4 libdw1 libelf1 zlib1g \
       # envsubst
       gettext-base \
-  && git clone https://github.com/bats-core/bats-core.git /tmp/bats \
-  && git -C /tmp/bats checkout --detach 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87 \
+  && git init /tmp/bats \
+  && git -C /tmp/bats remote add origin https://github.com/bats-core/bats-core.git \
+  && git -C /tmp/bats fetch --depth 1 origin 3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87 \
+  && git -C /tmp/bats checkout FETCH_HEAD \
   && /tmp/bats/install.sh /usr/local \
-  && git clone https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support \
-  && git -C /usr/local/lib/bats-support checkout --detach 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1 \
-  && git clone https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert \
-  && git -C /usr/local/lib/bats-assert checkout --detach f1e9280eaae8f86cbe278a687e6ba755bc802c1a \
-  && git clone https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file \
-  && git -C /usr/local/lib/bats-file checkout --detach 13ad5e2ffcc360281432db3d43a306f7b3667d60 \
+  && git clone --depth 1 https://github.com/bats-core/bats-support.git /usr/local/lib/bats-support \
+  && git -C /usr/local/lib/bats-support fetch --depth 1 origin 24a72e14349690bcbf7c151b9d2d1cdd32d36eb1 \
+  && git -C /usr/local/lib/bats-support checkout FETCH_HEAD \
+  && git clone --depth 1 https://github.com/bats-core/bats-assert.git /usr/local/lib/bats-assert \
+  && git -C /usr/local/lib/bats-assert fetch --depth 1 origin f1e9280eaae8f86cbe278a687e6ba755bc802c1a \
+  && git -C /usr/local/lib/bats-assert checkout FETCH_HEAD \
+  && git clone --depth 1 https://github.com/bats-core/bats-file.git /usr/local/lib/bats-file \
+  && git -C /usr/local/lib/bats-file fetch --depth 1 origin 13ad5e2ffcc360281432db3d43a306f7b3667d60 \
+  && git -C /usr/local/lib/bats-file checkout FETCH_HEAD \
   && rm -rf /tmp/bats \
       /usr/local/lib/bats-support/.git \
       /usr/local/lib/bats-assert/.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,20 +24,17 @@ RUN cargo build --release
 # builtin — build Rust loadable builtins
 # System lld (from apt) is required because export_name attributes contain
 # colons (e.g. ":args_struct") which cause "syntax error in VERSION script"
-# with GNU ld on arm64. Rust >=1.94 ships its own rust-lld shim (via
-# -B<sysroot>/bin/gcc-ld) that takes precedence when -fuse-ld=lld is used,
-# and rust-lld's version script parser also chokes on colon-prefixed symbols.
-# We override the shim with a symlink to the system lld so -fuse-ld=lld
-# resolves to the system lld instead of rust-lld.
+# with both GNU ld and rust-lld. System lld (Debian LLD 14) handles them.
+# -Clinker-features=-lld disables Rust's bundled rust-lld (default since 1.94)
+# so -fuse-ld=lld resolves to the system lld from apt.
+# See: https://github.com/rust-lang/rust/issues/38238
 FROM rust:1-slim-bookworm AS builtin-build
 RUN apt-get update && apt-get install -y --no-install-recommends lld && rm -rf /var/lib/apt/lists/*
-# Override Rust's bundled rust-lld shim so -fuse-ld=lld uses system lld.
-RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
 ARG RUSTFLAGS
 ARG CARGO_PROFILE_RELEASE_STRIP
 ARG CARGO_PROFILE_RELEASE_LTO
 ARG CARGO_PROFILE_RELEASE_PANIC
-ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
+ENV RUSTFLAGS="${RUSTFLAGS} -Clinker-features=-lld -C link-arg=-fuse-ld=lld"
 WORKDIR /build
 COPY builtin/ .
 RUN cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 # All the tools required to run the tests, lint and coverage Bash scripts
+#
+# Build modes:
+#   1. Extract Rust binaries:  docker buildx build --target artifacts -o out .
+#   2. Full image (local):     docker buildx build .
+#   3. Full image (CI):        Uses GHA cache from the build job so the Rust
+#                               stages are cache hits — only the final assembly
+#                               layers (tools, COPY argsh.min.sh) run fresh.
+
+# ── Rust build stages ────────────────────────────────────────────────────
 
 # minify — build Rust minifier
 FROM rust:1-slim-bookworm AS minifier-build
@@ -34,7 +43,6 @@ COPY builtin/ .
 RUN cargo build --release
 
 # argsh-lsp / argsh-lint — LSP server + CLI linter (share the same crate).
-# Builds both binaries in one cargo invocation.
 FROM rust:1-slim-bookworm AS lsp-build
 WORKDIR /build
 COPY crates/ crates/
@@ -47,6 +55,8 @@ COPY --from=shdoc-build /build/target/release/shdoc /shdoc
 COPY --from=builtin-build /build/target/release/libargsh.so /libargsh.so
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lsp /argsh-lsp
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-lint
+
+# ── Final image ──────────────────────────────────────────────────────────
 
 # coverage
 FROM kcov/kcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,18 @@ RUN cargo build --release
 # System lld (from apt) is required because export_name attributes contain
 # colons (e.g. ":args_struct") which cause "syntax error in VERSION script"
 # with both GNU ld and rust-lld. System lld (Debian LLD 14) handles them.
-# -Clinker-features=-lld disables Rust's bundled rust-lld (default since 1.94)
-# so -fuse-ld=lld resolves to the system lld from apt.
+# We symlink system lld over the rust-lld shim in gcc-ld/ so that
+# -fuse-ld=lld resolves to system lld on all architectures.
+# (-Clinker-features=-lld would be cleaner but is only stable on x86_64.)
 # See: https://github.com/rust-lang/rust/issues/38238
 FROM rust:1-slim-bookworm AS builtin-build
 RUN apt-get update && apt-get install -y --no-install-recommends lld && rm -rf /var/lib/apt/lists/*
+RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
 ARG RUSTFLAGS
 ARG CARGO_PROFILE_RELEASE_STRIP
 ARG CARGO_PROFILE_RELEASE_LTO
 ARG CARGO_PROFILE_RELEASE_PANIC
-ENV RUSTFLAGS="${RUSTFLAGS} -Clinker-features=-lld -C link-arg=-fuse-ld=lld"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
 WORKDIR /build
 COPY builtin/ .
 RUN cargo build --release


### PR DESCRIPTION
## Summary

Restructure the CI pipeline from "each job builds everything it needs" to **build once → fan out via Docker image artifact → fan in**.

### Pipeline diagram

```
build (amd64):  Dockerfile → artifacts + full Docker image → save as artifact (~52MB)
build (arm64):  Dockerfile → artifacts only (native runner, no QEMU)
         │
         ▼ (parallel, each does docker load)
┌────────┬────────┬──────────┬──────────┐
│  test  │  lint  │ coverage │  minify  │
│docker  │docker  │ direnv   │ docker   │
│load+run│load+run│ (rust)   │ load+run │
└────┬───┴────┬───┴────┬─────┴────┬─────┘
     └────────┴────────┴──────────┤
                                  ▼
                     docker (load + smoke test .docker/test/
                            + multi-arch build+push via cache)
                     minify-so
                     release (tag only)
```

### Key changes

| Change | Before | After |
|--------|--------|-------|
| **Base image** | `kcov/kcov` (236MB) | `debian:trixie-slim` + kcov binary copied in (144MB, **-39%**) |
| **Test/lint/minify** | Docker-in-Docker via `.bin/argsh` (builds full Dockerfile each time) | `docker load` CI image artifact + `docker run` |
| **arm64 build** | QEMU emulation (~28 min) | Native `ubuntu-24.04-arm` runner (~30s) |
| **Docker final image** | Full Dockerfile rebuild (~27 min) | GHA Buildx cache from build job (cache hit) |
| **Coverage** | 4 separate jobs | 1 merged job |
| **Stale binaries** | Extracted from `ghcr.io/arg-sh/argsh:latest` (previous release) | Fresh from current branch's build artifacts |
| **Rust compilations** | 24 total | 12 total |
| **Critical path** | ~37 min | ~7 min |

### Dockerfile changes

- Base: `debian:trixie-slim` instead of `kcov/kcov`
- kcov: `COPY --from=kcov/kcov` binary + apt runtime deps
- Symlink system lld over rust-lld shim (rust-lang/rust#38238)
- All tools in single apt layer: bash, curl, ca-certificates, kcov deps, gettext

### What runs where

| Job | Runs on | How |
|-----|---------|-----|
| test | ubuntu-latest | `docker load` CI image, `docker run ... test libraries/` (2× modes) |
| lint | ubuntu-latest | `docker load` CI image, `docker run ... lint libraries/` |
| minify | ubuntu-latest | `docker load` CI image, `docker run ... minify libraries -t ... -o ...` + lint + test |
| coverage | ubuntu-latest | direnv + `argsh coverage` (Rust toolchain, Docker for builtin .so) |
| docker | ubuntu-latest | `docker load` CI image for smoke test, then multi-arch build+push via cache |

## Test plan
- [x] All tests pass locally (bats pure-bash + builtin, Rust tests)
- [x] Docker image builds and runs tests/lint/minify correctly
- [x] kcov works in new image (`--security-opt seccomp=unconfined`)
- [ ] CI passes end-to-end (build → test/lint/coverage/minify → docker → smoke test)
- [ ] Tag push produces complete release with all artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)