### PR TITLE
fix: add argsh-dap to release pipeline, Docker image, and VSIX

### DIFF
--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -64,13 +64,13 @@ jobs:
           cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
       - name: Validate and make executables
         run: |
-          for f in out/minifier out/shdoc out/libargsh.so out/argsh-lsp out/argsh-lint; do
+          for f in out/minifier out/shdoc out/libargsh.so out/argsh-lsp out/argsh-lint out/argsh-dap; do
             if [[ ! -f "${f}" ]]; then
               echo "Missing expected artifact: ${f}" >&2
               exit 1
             fi
           done
-          chmod +x out/minifier out/shdoc out/argsh-lsp out/argsh-lint
+          chmod +x out/minifier out/shdoc out/argsh-lsp out/argsh-lint out/argsh-dap
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -449,6 +449,7 @@ jobs:
           mkdir -p dist
           cp crates/argsh-lsp/target/${{ matrix.target }}/release/argsh-lsp  dist/argsh-lsp-${{ matrix.platform }}
           cp crates/argsh-lsp/target/${{ matrix.target }}/release/argsh-lint dist/argsh-lint-${{ matrix.platform }}
+          cp crates/argsh-lsp/target/${{ matrix.target }}/release/argsh-dap  dist/argsh-dap-${{ matrix.platform }}
           chmod +x dist/*
 
       - uses: actions/upload-artifact@v7
@@ -460,6 +461,11 @@ jobs:
         with:
           name: argsh-lint-${{ matrix.platform }}
           path: dist/argsh-lint-${{ matrix.platform }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: argsh-dap-${{ matrix.platform }}
+          path: dist/argsh-dap-${{ matrix.platform }}
 
   package-vsix:
     name: Package VSCode extension (${{ matrix.platform }})
@@ -481,10 +487,17 @@ jobs:
           name: argsh-lsp-${{ matrix.platform }}
           path: vscode-argsh/bin/
 
-      - name: Prepare binary
+      - name: Download DAP binary
+        uses: actions/download-artifact@v8
+        with:
+          name: argsh-dap-${{ matrix.platform }}
+          path: vscode-argsh/bin/
+
+      - name: Prepare binaries
         run: |
           chmod +x vscode-argsh/bin/*
           mv vscode-argsh/bin/argsh-lsp-${{ matrix.platform }} vscode-argsh/bin/argsh-lsp
+          mv vscode-argsh/bin/argsh-dap-${{ matrix.platform }} vscode-argsh/bin/argsh-dap
 
       - name: Install and compile
         run: cd vscode-argsh && npm install && npm run compile
@@ -538,6 +551,12 @@ jobs:
           pattern: argsh-lint-*
           path: artifacts/lsp
           merge-multiple: true
+      - name: Download all argsh-dap binaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: argsh-dap-*
+          path: artifacts/lsp
+          merge-multiple: true
       - name: Download all VSIX packages
         uses: actions/download-artifact@v8
         with:
@@ -562,7 +581,8 @@ jobs:
           for p in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             cp "artifacts/lsp/argsh-lsp-${p}"  "release/argsh-lsp-${p}"
             cp "artifacts/lsp/argsh-lint-${p}" "release/argsh-lint-${p}"
-            chmod +x "release/argsh-lsp-${p}" "release/argsh-lint-${p}"
+            cp "artifacts/lsp/argsh-dap-${p}"  "release/argsh-dap-${p}"
+            chmod +x "release/argsh-lsp-${p}" "release/argsh-lint-${p}" "release/argsh-dap-${p}"
           done
 
           cp artifacts/vsix/*.vsix release/

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=shdoc-build /build/target/release/shdoc /shdoc
 COPY --from=builtin-build /build/target/release/libargsh.so /libargsh.so
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lsp /argsh-lsp
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-lint
+COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-dap /argsh-dap
 
 # ── Final image ──────────────────────────────────────────────────────────
 
@@ -108,6 +109,7 @@ COPY --from=shdoc-build /build/target/release/shdoc /usr/local/bin/shdoc
 COPY --from=builtin-build /build/target/release/libargsh.so /usr/local/lib/argsh.so
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lsp /usr/local/bin/argsh-lsp
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /usr/local/bin/argsh-lint
+COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-dap /usr/local/bin/argsh-dap
 COPY ./argsh.min.sh /usr/local/bin/argsh
 ENV ARGSH_BUILTIN_PATH=/usr/local/lib/argsh.so
 ENV BATS_LIB_PATH=/usr/local/lib

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -286,6 +286,15 @@ module.exports = {
       className: "homepage-sidebar-item",
     },
     {
+      type: "doc",
+      id: "development/tools/debugger",
+      label: "Debugger",
+      customProps: {
+        sidebar_icon: "bug",
+      },
+      className: "homepage-sidebar-item",
+    },
+    {
       type: "html",
       value: "Reference",
       customProps: {


### PR DESCRIPTION
argsh-dap was added in PR #98 but wasn't included in the release pipeline.

Adds argsh-dap to:
- **build-lsp**: package + upload per-platform artifact
- **package-vsix**: download + bundle into VSCode extension (alongside argsh-lsp)
- **release**: download + assemble into release assets (per-platform binaries)
- **Dockerfile**: artifacts stage + final image `/usr/local/bin/argsh-dap`
- **build validation**: check `out/argsh-dap` exists after Dockerfile build

After merge, re-tag v0.8.0 (or v0.8.1) to get argsh-dap in the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)