### PR TITLE
docs: add documentation for crates, builtin, and shdoc

### DIFF
--- a/builtin/README.md
+++ b/builtin/README.md
@@ -38,14 +38,15 @@ Build profile optimizes for size: LTO, `opt-level = "s"`, stripped symbols, sing
 
 ## Loading
 
-argsh searches for `libargsh.so` in this order:
+Cargo produces `target/release/libargsh.so`. At runtime, argsh searches for `argsh.so` (without the `lib` prefix) in this order:
 
-1. `ARGSH_BUILTIN_PATH` (explicit path)
+1. `ARGSH_BUILTIN_PATH` (explicit path to the `.so` file)
 2. `PATH_LIB/argsh.so`
 3. `PATH_BIN/argsh.so`
-4. `LD_LIBRARY_PATH/argsh.so`
-5. `BASH_LOADABLES_PATH/argsh.so`
-6. `~/.local/lib/bash/argsh.so`
+4. `LD_LIBRARY_PATH` directories
+5. `BASH_LOADABLES_PATH` directories
+
+The default install target is `~/.local/lib/bash/argsh.so` — found via `BASH_LOADABLES_PATH` if configured.
 
 Once found, all 18 builtins are registered via `enable -f <path> <name> ...`.
 

--- a/builtin/README.md
+++ b/builtin/README.md
@@ -1,0 +1,86 @@
+# builtin
+
+Bash loadable builtins implemented in Rust. Provides native-speed implementations of argsh's core functions, loaded at runtime via `enable -f`.
+
+## Builtins
+
+| Builtin | Description |
+| ------- | ----------- |
+| `:args` | Argument parsing with type checking and flag validation |
+| `args::field_name` | Extract variable name from field spec (`'flag\|f:~int!'` → `flag`) |
+| `:usage` | Subcommand dispatch from usage array |
+| `:usage::help` | Format and display help text |
+| `:usage::completion` | Generate bash/zsh/fish shell completions |
+| `:usage::docgen` | Generate docs (man, md, rst, yaml, llm formats) |
+| `:usage::mcp` | MCP server — expose commands as AI-callable tools |
+| `import` | Module loading with caching and selective function aliasing |
+| `import::clear` | Clear import cache for re-sourcing |
+| `is::array` | Test if variable is an array |
+| `is::set` | Test if variable is set |
+| `is::uninitialized` | Test if variable is uninitialized |
+| `is::tty` | Test if stdin is a TTY |
+| `to::int` | Validate integer |
+| `to::float` | Validate float |
+| `to::boolean` | Validate boolean |
+| `to::file` | Validate file path |
+| `to::string` | Validate string |
+
+All builtins have pure-bash fallbacks in `libraries/`. The `.so` is optional — argsh works without it, just slower.
+
+## Build
+
+```bash
+cargo build --release
+# Output: target/release/libargsh.so
+```
+
+Build profile optimizes for size: LTO, `opt-level = "s"`, stripped symbols, single codegen unit.
+
+## Loading
+
+argsh searches for `libargsh.so` in this order:
+
+1. `ARGSH_BUILTIN_PATH` (explicit path)
+2. `PATH_LIB/argsh.so`
+3. `PATH_BIN/argsh.so`
+4. `LD_LIBRARY_PATH/argsh.so`
+5. `BASH_LOADABLES_PATH/argsh.so`
+6. `~/.local/lib/bash/argsh.so`
+
+Once found, all 18 builtins are registered via `enable -f <path> <name> ...`.
+
+## Architecture
+
+```
+src/
+├── lib.rs          FFI types (WordList, WordDesc, BashBuiltin), word list parsing
+├── shell.rs        FFI bindings to bash internals (find_variable, parse_and_execute)
+├── args.rs         :args builtin — argument parsing with type checking
+├── field.rs        args::field_name — field definition parser
+├── shared.rs       Shared error handling and flag parsing for :args/:usage
+├── is.rs           is::* builtins — variable introspection
+├── to.rs           to::* builtins — type validation/conversion
+├── import.rs       import/import::clear — module loading with caching
+└── usage/
+    ├── mod.rs          :usage/:usage::help — subcommand dispatch and help
+    ├── completion.rs   :usage::completion — shell completion generation
+    ├── docgen.rs       :usage::docgen — documentation generation
+    └── mcp.rs          :usage::mcp — MCP server for AI agent integration
+```
+
+## Testing
+
+```bash
+# Unit + integration tests
+cargo test
+
+# Test with builtin loaded (in argsh test suite)
+ARGSH_BUILTIN_TEST=1 bats tests/
+
+# Test pure-bash fallbacks (skips builtin)
+ARGSH_PURE_BASH_TEST=1 bats tests/
+```
+
+## Safety
+
+Never overwrite a loaded `.so` in place — bash will segfault. The `argsh builtin update` command downloads to a temp file and does an atomic `mv`.

--- a/crates/docs/README.md
+++ b/crates/docs/README.md
@@ -1,0 +1,73 @@
+# Crates
+
+This directory contains the Rust crates that power argsh's tooling:
+
+| Crate | Purpose | Binaries |
+|-------|---------|----------|
+| [argsh-syntax](argsh-syntax.md) | Parsing library — field definitions, usage entries, document analysis | (library only) |
+| [argsh-lsp](argsh-lsp.md) | Language server, CLI linter, and DAP debugger | `argsh-lsp`, `argsh-lint`, `argsh-dap` |
+
+## Architecture
+
+```
+argsh-syntax (library)
+    │
+    ├── document analysis (functions, args, usage, imports)
+    ├── field parsing (modifiers, types, flags vs positionals)
+    ├── usage parsing (commands, aliases, annotations)
+    └── scope analysis (variable declarations, shadowing)
+         │
+         ▼
+argsh-lsp (library + 3 binaries)
+    │
+    ├── lib.rs ──── shared modules ────┐
+    │   ├── diagnostics.rs             │ reused by all 3 binaries
+    │   └── resolver.rs                │
+    │                                  │
+    ├── argsh-lsp (bin) ◄──────────────┤ Language Server Protocol
+    │   ├── backend.rs                 │   (tower-lsp, stdio)
+    │   ├── completion.rs              │
+    │   ├── hover.rs                   │
+    │   ├── goto_def.rs                │
+    │   ├── format.rs                  │
+    │   ├── codelens.rs                │
+    │   ├── preview.rs                 │
+    │   ├── rename.rs                  │
+    │   ├── symbols.rs                 │
+    │   └── util.rs                    │
+    │                                  │
+    ├── argsh-lint (bin) ◄─────────────┤ CLI linter
+    │   └── shellcheck-compatible      │   (gcc/json/checkstyle output)
+    │       flags & formats            │
+    │                                  │
+    └── argsh-dap (bin) ◄──────────────┘ Debug Adapter Protocol
+        └── bash DEBUG trap                (breakpoints, stepping,
+            + FIFO protocol                 variable inspection)
+```
+
+## Building
+
+```bash
+# Build all crates
+cd crates/argsh-lsp && cargo build --release
+
+# This produces 3 binaries:
+# target/release/argsh-lsp   — language server
+# target/release/argsh-lint  — CLI linter
+# target/release/argsh-dap   — DAP debugger
+
+# argsh-syntax is built automatically as a dependency
+```
+
+## Testing
+
+```bash
+# All tests (syntax + LSP + lint CLI + DAP integration + DAP E2E)
+cargo test --release
+
+# Individual test suites
+cargo test --release --test integration    # LSP protocol tests
+cargo test --release --test lint_cli       # argsh-lint CLI tests
+cargo test --release --test dap_integration # DAP protocol tests
+cargo test --release --test dap_e2e        # DAP end-to-end tests
+```

--- a/crates/docs/README.md
+++ b/crates/docs/README.md
@@ -62,12 +62,15 @@ cd crates/argsh-lsp && cargo build --release
 ## Testing
 
 ```bash
-# All tests (syntax + LSP + lint CLI + DAP integration + DAP E2E)
-cargo test --release
+# argsh-syntax unit tests
+cd crates/argsh-syntax && cargo test --release
 
-# Individual test suites
-cargo test --release --test integration    # LSP protocol tests
-cargo test --release --test lint_cli       # argsh-lint CLI tests
-cargo test --release --test dap_integration # DAP protocol tests
-cargo test --release --test dap_e2e        # DAP end-to-end tests
+# argsh-lsp tests (LSP + lint CLI + DAP integration + DAP E2E)
+cd crates/argsh-lsp && cargo test --release
+
+# Individual argsh-lsp test suites
+cd crates/argsh-lsp && cargo test --release --test integration     # LSP protocol tests
+cd crates/argsh-lsp && cargo test --release --test lint_cli        # argsh-lint CLI tests
+cd crates/argsh-lsp && cargo test --release --test dap_integration # DAP protocol tests
+cd crates/argsh-lsp && cargo test --release --test dap_e2e         # DAP end-to-end tests
 ```

--- a/crates/docs/argsh-lsp.md
+++ b/crates/docs/argsh-lsp.md
@@ -117,7 +117,7 @@ Suppress per-line with `# argsh-ignore=AG004,AG012` or `# argsh disable=AG004`.
 
 ## Resolver
 
-`resolver.rs` follows `import` and `source` statements across files to build a merged `DocumentAnalysis`. Resolution depth is configurable (0–5, default 2).
+`resolver.rs` follows `import` and `source` statements across files to build a merged `DocumentAnalysis`. Resolution depth is configurable (0+, default 2).
 
 Search order for imports:
 1. Relative to the importing file's directory

--- a/crates/docs/argsh-lsp.md
+++ b/crates/docs/argsh-lsp.md
@@ -1,0 +1,154 @@
+# argsh-lsp
+
+Library and three binaries for argsh tooling: language server, CLI linter, and DAP debugger. Built on top of `argsh-syntax` for all analysis.
+
+## Binaries
+
+### `argsh-lsp` — Language Server
+
+Full LSP implementation over stdio using `tower-lsp`. Activates on `shellscript` files containing `source argsh` or `#!/usr/bin/env argsh`.
+
+Features:
+
+| Feature | Module | Description |
+| ------- | ------ | ----------- |
+| Diagnostics | `diagnostics.rs` | AG001–AG013 checks (see below) |
+| Completions | `completion.rs` | Modifiers, types, annotations, function names, library functions |
+| Hover | `hover.rs` | Generated `--help` output, args/usage entry details, subcommand help |
+| Go to definition | `goto_def.rs` | Usage entries, `:-` mappings, `:~custom` types, imports |
+| Code lens | `codelens.rs` | Branch/leaf icons with flag/subcommand counts |
+| Formatting | `format.rs` | Aligns `args=()`/`usage=()` array entries |
+| Preview | `preview.rs` | HTML dashboard with command tree, MCP tools, export links |
+| Rename | `rename.rs` | Rename function across definition, usage entries, and references |
+| Symbols | `symbols.rs` | Document outline with namespace nesting |
+| Cross-file | `resolver.rs` | Follows `import` and `source` across files (configurable depth) |
+
+### `argsh-lint` — CLI Linter
+
+Standalone linter that reuses the same diagnostics engine as the LSP. Designed for CI pipelines and editor-less workflows.
+
+```bash
+# Lint a single file
+argsh-lint script.sh
+
+# Lint multiple files
+argsh-lint lib/*.sh
+
+# Output formats (shellcheck-compatible flags)
+argsh-lint -f gcc script.sh        # default: file:line:col: level: message [CODE]
+argsh-lint -f json script.sh       # JSON array
+argsh-lint -f checkstyle script.sh # Checkstyle XML
+
+# Filter by severity
+argsh-lint -S warning script.sh    # warnings and above
+argsh-lint -S error script.sh      # errors only
+
+# Exclude specific codes
+argsh-lint -e AG004,AG010 script.sh
+
+# Cross-file resolution
+argsh-lint --resolve-depth 2 script.sh  # follow imports up to 2 levels
+```
+
+Exit codes: `0` = no issues, `1` = issues found.
+
+### `argsh-dap` — Debug Adapter Protocol
+
+Step-through bash debugger using bash's built-in `DEBUG` trap (no external dependencies like bashdb).
+
+```bash
+# Start DAP server (communicates over stdio, same framing as LSP)
+argsh-dap
+```
+
+Architecture:
+
+```
+VSCode ←→ argsh-dap (Rust, DAP over stdio)
+               ↕
+         Named FIFOs (per-PID)
+               ↕
+         bash process (DEBUG trap + FIFO protocol)
+```
+
+Features:
+- Breakpoints: file:line, conditional (`(( i == 3 ))`), by subcommand name (smart breakpoints)
+- Stepping: step in (into functions), step over, step out
+- Call stack: full `FUNCNAME`/`BASH_SOURCE` trace with argsh namespace resolution
+- Variable inspection: argsh Args scope shows `:args` field definitions with types
+- Watch expressions and set-variable-at-runtime
+- Subshell/pipe/background job support (per-PID control FIFOs + flock serialization)
+- Auto-launch configs: suggests debug configurations based on script analysis
+
+## Shared Library (`lib.rs`)
+
+The `argsh-lsp` crate re-exports two modules used by all three binaries:
+
+```rust
+pub mod diagnostics;  // AG001–AG013 diagnostic generation
+pub mod resolver;     // Cross-file import resolution
+```
+
+## Diagnostics
+
+| Code | Severity | Description |
+| ---- | -------- | ----------- |
+| AG001 | Warning | `args` entry missing description |
+| AG002 | Warning | `usage` entry missing description |
+| AG003 | Error | Invalid field spec (bad modifier) |
+| AG004 | Warning | Missing `local` variable declaration |
+| AG005 | Warning | `args` array declared but `:args` not called |
+| AG006 | Warning | `usage` array declared but `:usage` not called |
+| AG007 | Error | Usage target function not found |
+| AG008 | Error | Duplicate flag name |
+| AG009 | Error | Duplicate short alias |
+| AG010 | Info | Command resolves to bare function (not namespaced) |
+| AG012 | Warning | Local variable shadows parent scope args field |
+| AG013 | Warning | Import could not be resolved |
+
+Suppress per-line with `# argsh-ignore=AG004,AG012` or `# argsh disable=AG004`.
+
+## Resolver
+
+`resolver.rs` follows `import` and `source` statements across files to build a merged `DocumentAnalysis`. Resolution depth is configurable (0–5, default 2).
+
+Search order for imports:
+1. Relative to the importing file's directory
+2. Standard library paths (`libraries/`)
+3. Workspace root
+
+## Source Layout
+
+```
+src/
+├── lib.rs             Shared modules (diagnostics, resolver)
+├── main.rs            argsh-lsp binary entry point
+├── backend.rs         LSP server implementation (tower-lsp Backend trait)
+├── completion.rs      Completions (modifiers, types, annotations, functions)
+├── diagnostics.rs     AG001–AG013 diagnostic generation
+├── hover.rs           Hover info (help text, args/usage details)
+├── goto_def.rs        Go-to-definition (usage entries, imports, types)
+├── codelens.rs        Code lens (flag/subcommand counts)
+├── format.rs          Array entry alignment formatter
+├── preview.rs         HTML preview generation (script dashboard)
+├── rename.rs          Rename support (functions across refs)
+├── symbols.rs         Document symbols (outline with namespaces)
+├── resolver.rs        Cross-file import resolution
+├── util.rs            Word extraction helper
+└── bin/
+    ├── argsh-lint.rs  CLI linter binary
+    └── argsh-dap.rs   DAP debugger binary
+
+tests/
+├── integration.rs     LSP protocol tests
+├── lint_cli.rs        argsh-lint CLI tests
+├── dap_integration.rs DAP protocol tests (9 tests)
+└── dap_e2e.rs         DAP end-to-end tests (22 tests)
+```
+
+## Dependencies
+
+- `tower-lsp` — LSP server framework
+- `tokio` — async runtime
+- `serde` / `serde_json` — DAP message serialization
+- `argsh-syntax` — parsing library (workspace dependency)

--- a/crates/docs/argsh-lsp.md
+++ b/crates/docs/argsh-lsp.md
@@ -36,21 +36,27 @@ argsh-lint lib/*.sh
 
 # Output formats (shellcheck-compatible flags)
 argsh-lint -f gcc script.sh        # default: file:line:col: level: message [CODE]
-argsh-lint -f json script.sh       # JSON array
+argsh-lint -f tty script.sh        # colorized output with ANSI codes
+argsh-lint -f json script.sh       # JSON object per line
 argsh-lint -f checkstyle script.sh # Checkstyle XML
+argsh-lint -f quiet script.sh      # no output, exit code only
 
 # Filter by severity
 argsh-lint -S warning script.sh    # warnings and above
 argsh-lint -S error script.sh      # errors only
 
-# Exclude specific codes
+# Exclude / include specific codes
 argsh-lint -e AG004,AG010 script.sh
+argsh-lint -i AG001,AG003 script.sh  # only these codes
 
-# Cross-file resolution
-argsh-lint --resolve-depth 2 script.sh  # follow imports up to 2 levels
+# Skip cross-file resolution (faster, skips AG013)
+argsh-lint --no-resolve script.sh
+
+# Colorize control
+argsh-lint -C always script.sh     # auto (default), always, never
 ```
 
-Exit codes: `0` = no issues, `1` = issues found.
+Exit codes: `0` = no issues, `1` = issues found, `2` = CLI/IO error.
 
 ### `argsh-dap` — Debug Adapter Protocol
 
@@ -93,17 +99,18 @@ pub mod resolver;     // Cross-file import resolution
 
 | Code | Severity | Description |
 | ---- | -------- | ----------- |
-| AG001 | Warning | `args` entry missing description |
-| AG002 | Warning | `usage` entry missing description |
+| AG001 | Error | `args` entry missing description |
+| AG002 | Error | `usage` entry missing description |
 | AG003 | Error | Invalid field spec (bad modifier) |
 | AG004 | Warning | Missing `local` variable declaration |
-| AG005 | Warning | `args` array declared but `:args` not called |
-| AG006 | Warning | `usage` array declared but `:usage` not called |
-| AG007 | Error | Usage target function not found |
-| AG008 | Error | Duplicate flag name |
-| AG009 | Error | Duplicate short alias |
-| AG010 | Info | Command resolves to bare function (not namespaced) |
-| AG012 | Warning | Local variable shadows parent scope args field |
+| AG005 | Error | `args` array declared but `:args` not called |
+| AG006 | Error | `usage` array declared but `:usage` not called |
+| AG007 | Warning | Usage target function not found |
+| AG008 | Warning | Duplicate flag name |
+| AG009 | Warning | Duplicate short alias |
+| AG010 | Warning | Command resolves to bare function (not namespaced) |
+| ~~AG011~~ | — | *(removed)* Trailing `\|` is valid syntax for long-only flags |
+| AG012 | Hint | Local variable shadows parent scope args field |
 | AG013 | Warning | Import could not be resolved |
 
 Suppress per-line with `# argsh-ignore=AG004,AG012` or `# argsh disable=AG004`.
@@ -152,3 +159,7 @@ tests/
 - `tokio` — async runtime
 - `serde` / `serde_json` — DAP message serialization
 - `argsh-syntax` — parsing library (workspace dependency)
+- `dashmap` — concurrent document cache
+- `regex` — pattern matching
+- `tempfile` — temporary file handling
+- `libc` — platform bindings (unix only)

--- a/crates/docs/argsh-lsp.md
+++ b/crates/docs/argsh-lsp.md
@@ -117,7 +117,7 @@ Suppress per-line with `# argsh-ignore=AG004,AG012` or `# argsh disable=AG004`.
 
 ## Resolver
 
-`resolver.rs` follows `import` and `source` statements across files to build a merged `DocumentAnalysis`. Resolution depth is configurable (0+, default 2).
+`resolver.rs` follows `import` statements across files to build a merged `DocumentAnalysis`, and handles the special case `source argsh` by loading `main.sh`/`args.sh`. Resolution depth is configurable (0+, default 2).
 
 Search order for imports:
 1. Relative to the importing file's directory
@@ -158,7 +158,7 @@ tests/
 - `tower-lsp` — LSP server framework
 - `tokio` — async runtime
 - `serde` / `serde_json` — DAP message serialization
-- `argsh-syntax` — parsing library (workspace dependency)
+- `argsh-syntax` — parsing library (path dependency)
 - `dashmap` — concurrent document cache
 - `regex` — pattern matching
 - `tempfile` — temporary file handling

--- a/crates/docs/argsh-lsp.md
+++ b/crates/docs/argsh-lsp.md
@@ -6,7 +6,7 @@ Library and three binaries for argsh tooling: language server, CLI linter, and D
 
 ### `argsh-lsp` — Language Server
 
-Full LSP implementation over stdio using `tower-lsp`. Activates on `shellscript` files containing `source argsh` or `#!/usr/bin/env argsh`.
+Full LSP implementation over stdio using `tower-lsp`. Activates on `shellscript` files containing `source argsh`, `#!/usr/bin/env argsh`, or any function that calls `:args`/`:usage`.
 
 Features:
 
@@ -21,7 +21,7 @@ Features:
 | Preview | `preview.rs` | HTML dashboard with command tree, MCP tools, export links |
 | Rename | `rename.rs` | Rename function across definition, usage entries, and references |
 | Symbols | `symbols.rs` | Document outline with namespace nesting |
-| Cross-file | `resolver.rs` | Follows `import` and `source` across files (configurable depth) |
+| Cross-file | `resolver.rs` | Follows `import` across files plus special-case `source argsh` (configurable depth) |
 
 ### `argsh-lint` — CLI Linter
 
@@ -122,7 +122,7 @@ Suppress per-line with `# argsh-ignore=AG004,AG012` or `# argsh disable=AG004`.
 Search order for imports:
 1. Relative to the importing file's directory
 2. Standard library paths (`libraries/`)
-3. Workspace root
+3. Project root (detected by `.git`, `.envrc`, or `.bin/argsh`)
 
 ## Source Layout
 
@@ -149,8 +149,8 @@ src/
 tests/
 ├── integration.rs     LSP protocol tests
 ├── lint_cli.rs        argsh-lint CLI tests
-├── dap_integration.rs DAP protocol tests (9 tests)
-└── dap_e2e.rs         DAP end-to-end tests (22 tests)
+├── dap_integration.rs DAP protocol tests
+└── dap_e2e.rs         DAP end-to-end tests
 ```
 
 ## Dependencies

--- a/crates/docs/argsh-syntax.md
+++ b/crates/docs/argsh-syntax.md
@@ -1,0 +1,102 @@
+# argsh-syntax
+
+Pure Rust parsing library for argsh scripts. Provides static analysis of bash files without executing them — extracts function definitions, `:args`/`:usage` declarations, field specifications, import statements, and variable scopes.
+
+Used by `argsh-lsp`, `argsh-lint`, and `argsh-dap` as the shared analysis foundation.
+
+## Modules
+
+### `document` — Document Analysis
+
+The core module. `analyze(content: &str) -> DocumentAnalysis` parses a bash script and extracts:
+
+- **Functions** — name, line range, whether it calls `:args` or `:usage`
+- **Args entries** — field specs (`'name|n:!'`), descriptions, parsed field definitions
+- **Usage entries** — command names, aliases, explicit function mappings (`:-func`), annotations (`@readonly`)
+- **Imports** — `import` and `source` statements with module names
+- **Shebangs** — detects `#!/usr/bin/env argsh` and `source argsh`
+
+```rust
+use argsh_syntax::document::analyze;
+
+let analysis = analyze(r#"
+main() {
+  local name
+  local -a args=(
+    'name|n:!' "Name of the person"
+  )
+  :args "Greet someone" "${@}"
+}
+"#);
+
+assert_eq!(analysis.functions.len(), 1);
+assert_eq!(analysis.functions[0].name, "main");
+assert!(analysis.functions[0].calls_args);
+assert_eq!(analysis.functions[0].args_entries.len(), 1);
+assert_eq!(analysis.functions[0].args_entries[0].spec, "name|n:!");
+```
+
+Key types:
+
+| Type | Description |
+|------|-------------|
+| `DocumentAnalysis` | Top-level result: functions, imports, shebang flags |
+| `FunctionInfo` | A function with its args/usage entries, line range, calls_args/calls_usage flags |
+| `ArgsArrayEntry` | A single entry from the `args=()` array: spec, description, parsed FieldDef |
+| `UsageEntry` | A single entry from the `usage=()` array: name, aliases, annotations |
+
+### `field` — Field Specification Parser
+
+Parses argsh field specs like `'name|n:~int!'` into structured definitions.
+
+```rust
+use argsh_syntax::field::parse_field;
+
+let field = parse_field("port|p:~int!").unwrap();
+assert_eq!(field.name, "port");
+assert_eq!(field.short, Some("p".to_string()));
+assert_eq!(field.type_name, "int");
+assert!(field.required);
+assert!(!field.is_boolean);
+assert!(field.is_flag); // has | separator
+```
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Variable name (before `\|`) |
+| `short` | Short alias (after `\|`, single char) |
+| `type_name` | Type constraint after `:~` (int, float, file, etc.) |
+| `is_boolean` | `:+` modifier — flag takes no value, sets to 1 |
+| `required` | `:!` modifier — must be provided |
+| `is_flag` | Contains `\|` — matched by `--name` / `-n` |
+| `is_hidden` | `#` prefix — excluded from help text |
+
+### `usage` — Usage Entry Parser
+
+Parses `:usage` array entries like `'deploy|d@destructive'`.
+
+```rust
+use argsh_syntax::usage::parse_usage_entry;
+
+let entry = parse_usage_entry("deploy|d@destructive");
+assert_eq!(entry.name, "deploy");
+assert_eq!(entry.aliases, vec!["deploy", "d"]);
+assert_eq!(entry.annotations, vec!["destructive"]);
+assert!(!entry.hidden);
+assert!(entry.explicit_func.is_none());
+```
+
+Special syntax:
+- `cmd|alias` — command with alias
+- `cmd:-func` — explicit function mapping (bypasses namespace resolution)
+- `cmd@annotation` — annotations (readonly, destructive, json, etc.)
+- `#cmd` — hidden from help text
+- `-` — group separator
+
+### `scope` — Variable Scope Analysis
+
+Tracks `local` variable declarations per function for diagnostics like AG004 (missing local declaration) and AG012 (variable shadows parent scope).
+
+## No Dependencies
+
+`argsh-syntax` depends only on `regex` — no async runtime, no LSP types, no I/O. This makes it suitable for embedding in any Rust tool that needs to understand argsh scripts.

--- a/crates/docs/argsh-syntax.md
+++ b/crates/docs/argsh-syntax.md
@@ -13,8 +13,8 @@ The core module. `analyze(content: &str) -> DocumentAnalysis` parses a bash scri
 - **Functions** — name, line range, whether it calls `:args` or `:usage`
 - **Args entries** — field specs (`'name|n:!'`), descriptions, parsed field definitions
 - **Usage entries** — command names, aliases, explicit function mappings (`:-func`), annotations (`@readonly`)
-- **Imports** — `import` and `source` statements with module names
-- **Shebangs** — detects `#!/usr/bin/env argsh` and `source argsh`
+- **Imports** — `import` statements with module names
+- **Argsh detection** — detects `#!/usr/bin/env argsh` shebang and `source argsh` markers
 
 ```rust
 use argsh_syntax::document::analyze;

--- a/crates/docs/argsh-syntax.md
+++ b/crates/docs/argsh-syntax.md
@@ -2,7 +2,7 @@
 
 Pure Rust parsing library for argsh scripts. Provides static analysis of bash files without executing them — extracts function definitions, `:args`/`:usage` declarations, field specifications, import statements, and variable scopes.
 
-Used by `argsh-lsp`, `argsh-lint`, and `argsh-dap` as the shared analysis foundation.
+Used by the `argsh-lsp` crate (which produces the `argsh-lsp`, `argsh-lint`, and `argsh-dap` binaries) as the shared analysis foundation.
 
 ## Modules
 
@@ -58,7 +58,7 @@ assert_eq!(field.short, Some("p".to_string()));
 assert_eq!(field.type_name, "int");
 assert!(field.required);
 assert!(!field.is_boolean);
-assert!(field.is_flag); // has | separator
+assert!(!field.is_positional); // has | separator → it's a flag
 ```
 
 | Field | Meaning |
@@ -68,8 +68,10 @@ assert!(field.is_flag); // has | separator
 | `type_name` | Type constraint after `:~` (int, float, file, etc.) |
 | `is_boolean` | `:+` modifier — flag takes no value, sets to 1 |
 | `required` | `:!` modifier — must be provided |
-| `is_flag` | Contains `\|` — matched by `--name` / `-n` |
-| `is_hidden` | `#` prefix — excluded from help text |
+| `is_positional` | No `\|` in definition — positional parameter (not a `--flag`) |
+| `hidden` | `#` prefix — excluded from help text |
+| `display_name` | Original name preserving dashes (vs `name` which replaces `-` with `_`) |
+| `raw` | Original spec string, preserved for diagnostics |
 
 ### `usage` — Usage Entry Parser
 

--- a/shdoc/README.md
+++ b/shdoc/README.md
@@ -1,0 +1,119 @@
+# shdoc
+
+Documentation generator for bash scripts and Rust source files. Extracts `# @annotation` tags from bash and `///` doc comments from Rust, producing Markdown, HTML, or JSON output.
+
+## Usage
+
+```bash
+# stdin mode (backward compatible)
+shdoc < file.sh
+
+# File mode (batch processing)
+shdoc -o docs/ libraries/*.sh builtin/src/*.rs
+
+# With prefix template
+shdoc -o docs/ -p _prefix.mdx libraries/*.sh
+
+# Output formats
+shdoc -f markdown < file.sh   # default
+shdoc -f html < file.sh
+shdoc -f json < file.sh
+
+# Filter by tags
+shdoc --filter core libraries/*.sh
+shdoc --filter '!deprecated' libraries/*.sh
+```
+
+## Annotations
+
+### File-level
+
+```bash
+# @file module-name
+# @brief Short description
+# @description
+#   Multi-line description text.
+# @tags core, validation
+```
+
+### Function-level
+
+```bash
+# @description Convert a value to an integer
+# @arg $1 any value to convert
+# @option -s | --strict Strict mode
+# @stdout The converted integer
+# @stderr Error message on failure
+# @exitcode 0 Success
+# @exitcode 1 Not a valid integer
+# @example
+#   to::int "42"    # 42
+#   to::int "abc"   # error
+# @set RESULT The conversion result
+# @see to::float
+# @internal
+# @tags core
+to::int() { ... }
+```
+
+### Rust doc comments
+
+```rust
+//! Module description (file-level)
+//! Mirrors: libraries/to.sh
+
+/// Function description
+#[export_name = "to::int_struct"]
+pub static mut TO_INT_STRUCT: BashBuiltin = ...;
+```
+
+## Cross-language Merge
+
+When bash and Rust files define functions with the same canonical name, shdoc merges them into a single documentation entry. Bash annotations take priority.
+
+```bash
+# Input: libraries/to.sh + builtin/src/to.rs → docs/to.mdx
+shdoc -o docs/ libraries/to.sh builtin/src/to.rs
+```
+
+## Output
+
+Markdown output includes:
+- YAML frontmatter (from `@tags`)
+- Module description
+- Function index
+- Per-function sections: description, badges (`Bash`/`Rust`), examples, options, arguments, exit codes, see-also
+
+## Build
+
+```bash
+cargo build --release
+# Binary: target/release/shdoc
+```
+
+## Test
+
+```bash
+cargo test
+
+# Fixture-based tests compare output against .expected.md files
+```
+
+## Architecture
+
+```
+src/
+├── main.rs            CLI, file I/O, filtering, mode dispatch
+├── model.rs           Data model (Document, FunctionDoc, ArgEntry)
+├── toc.rs             Table-of-contents and anchor generation
+├── parser/
+│   ├── mod.rs         Parser dispatch by file extension
+│   ├── bash.rs        State machine for # @annotation tags
+│   ├── rust.rs        Doc comment parser for .rs files
+│   └── merge.rs       Cross-language merge by canonical function name
+└── render/
+    ├── mod.rs         Renderer trait and factory
+    ├── markdown.rs    GitHub-flavored Markdown (mdx)
+    ├── html.rs        Standalone HTML pages
+    └── json.rs        Structured JSON output
+```

--- a/shdoc/README.md
+++ b/shdoc/README.md
@@ -1,6 +1,6 @@
 # shdoc
 
-Documentation generator for bash scripts and Rust source files. Extracts `# @annotation` tags from bash and `//!`/`///` doc comments from Rust, producing Markdown, HTML, or JSON output.
+Documentation generator for bash scripts and Rust source files. Extracts `# @` tags from bash and `//!`/`///` doc comments from Rust, producing Markdown, HTML, or JSON output.
 
 ## Usage
 
@@ -117,7 +117,7 @@ src/
 ├── toc.rs             Table-of-contents and anchor generation
 ├── parser/
 │   ├── mod.rs         Parser dispatch by file extension
-│   ├── bash.rs        State machine for # @annotation tags
+│   ├── bash.rs        State machine for # @file/# @description/etc. directives
 │   ├── rust.rs        Doc comment parser for .rs files
 │   └── merge.rs       Cross-language merge by canonical function name
 └── render/

--- a/shdoc/README.md
+++ b/shdoc/README.md
@@ -1,6 +1,6 @@
 # shdoc
 
-Documentation generator for bash scripts and Rust source files. Extracts `# @annotation` tags from bash and `///` doc comments from Rust, producing Markdown, HTML, or JSON output.
+Documentation generator for bash scripts and Rust source files. Extracts `# @annotation` tags from bash and `//!`/`///` doc comments from Rust, producing Markdown, HTML, or JSON output.
 
 ## Usage
 
@@ -22,6 +22,12 @@ shdoc -f json < file.sh
 # Filter by tags
 shdoc --filter core libraries/*.sh
 shdoc --filter '!deprecated' libraries/*.sh
+
+# Include @internal functions
+shdoc --show-internal -o docs/ libraries/*.sh
+
+# Disable YAML frontmatter
+shdoc --no-frontmatter -o docs/ libraries/*.sh
 ```
 
 ## Annotations
@@ -29,10 +35,11 @@ shdoc --filter '!deprecated' libraries/*.sh
 ### File-level
 
 ```bash
-# @file module-name
+# @file module-name        (alias: @name)
 # @brief Short description
 # @description
 #   Multi-line description text.
+# @section Section Name
 # @tags core, validation
 ```
 
@@ -40,8 +47,10 @@ shdoc --filter '!deprecated' libraries/*.sh
 
 ```bash
 # @description Convert a value to an integer
+# @noargs
 # @arg $1 any value to convert
 # @option -s | --strict Strict mode
+# @stdin Input from pipe (if applicable)
 # @stdout The converted integer
 # @stderr Error message on failure
 # @exitcode 0 Success


### PR DESCRIPTION
## Summary

- **crates/docs/**: Architecture overview, argsh-syntax API docs, argsh-lsp/lint/dap documentation with diagnostics reference (AG001–AG013)
- **builtin/README.md**: Loadable builtins table, FFI architecture, loading order, safety notes
- **shdoc/README.md**: Documentation generator with full annotations reference, cross-language merge, output formats
- **minifier/README.md**: Already existed (no changes)

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Check internal links between crates/docs/ files work

🤖 Generated with [Claude Code](https://claude.com/claude-code)