### PR TITLE
fix(lsp): recognize leaf functions without args=() array

### DIFF
--- a/crates/argsh-lsp/coverage.json
+++ b/crates/argsh-lsp/coverage.json
@@ -43,17 +43,17 @@
       "excluded_lines": "0"
     },
     {
-      "file": "crates/argsh-lsp/tests/integration.rs",
-      "percent_covered": "93.53",
-      "covered_lines": "1229",
-      "total_lines": "1314",
+      "file": "crates/argsh-lsp/src/codelens.rs",
+      "percent_covered": "93.75",
+      "covered_lines": "105",
+      "total_lines": "112",
       "excluded_lines": "0"
     },
     {
-      "file": "crates/argsh-lsp/src/codelens.rs",
-      "percent_covered": "92.86",
-      "covered_lines": "104",
-      "total_lines": "112",
+      "file": "crates/argsh-lsp/tests/integration.rs",
+      "percent_covered": "93.56",
+      "covered_lines": "1250",
+      "total_lines": "1336",
       "excluded_lines": "0"
     },
     {
@@ -162,12 +162,12 @@
       "excluded_lines": "0"
     }
   ],
-  "percent_covered": "81.53",
-  "covered_lines": 6464,
-  "total_lines": 7928,
+  "percent_covered": "81.58",
+  "covered_lines": 6486,
+  "total_lines": 7950,
   "excluded_lines": 0,
   "percent_low": 25,
   "percent_high": 75,
   "command": "cargo-test+llvm-cov",
-  "date": "2026-04-19 16:31:14"
+  "date": "2026-04-19 16:58:50"
 }

--- a/crates/argsh-lsp/src/codelens.rs
+++ b/crates/argsh-lsp/src/codelens.rs
@@ -14,7 +14,7 @@ pub fn code_lenses(analysis: &DocumentAnalysis, uri: &Url) -> Vec<CodeLens> {
         .collect();
 
     for func in &analysis.functions {
-        let has_args = func.calls_args && !func.args_entries.is_empty();
+        let has_args = func.calls_args;
         let has_usage = func.calls_usage && !func.usage_entries.is_empty();
 
         if !has_args && !has_usage {

--- a/crates/argsh-lsp/tests/integration.rs
+++ b/crates/argsh-lsp/tests/integration.rs
@@ -1666,6 +1666,45 @@ fn test_code_lens_shows_parent_link() {
 }
 
 #[test]
+fn test_code_lens_no_args_leaf() {
+    let mut client = LspTestClient::new();
+    client.initialize();
+
+    // A function that calls :args but has no args=() array (no flags/params, just a title)
+    let content = "#!/usr/bin/env bash\nsource argsh\nlist() {\n  :args \"List secrets\" \"${@}\"\n  echo \"listing...\"\n}\n";
+    client.open_document("file:///test_noargs.sh", content);
+
+    let resp = client.send_request(
+        "textDocument/codeLens",
+        json!({
+            "textDocument": { "uri": "file:///test_noargs.sh" }
+        }),
+    );
+    assert!(
+        resp.get("error").is_none(),
+        "CodeLens error: {:?}",
+        resp["error"]
+    );
+    let result = &resp["result"];
+    assert!(result.is_array(), "CodeLens should return array");
+    let lenses = result.as_array().unwrap();
+    assert!(
+        !lenses.is_empty(),
+        "Expected a code lens for list() even without args=() array"
+    );
+
+    // Should show as a leaf (terminal icon)
+    let title = lenses[0]["command"]["title"].as_str().unwrap();
+    assert!(
+        title.contains("$(terminal)"),
+        "No-args leaf should show terminal icon, got: {}",
+        title
+    );
+
+    client.shutdown();
+}
+
+#[test]
 fn test_settings_resolve_depth_passed() {
     let mut client = LspTestClient::new();
     // Initialize with custom resolveDepth


### PR DESCRIPTION
## Summary

- Functions that call `:args` but have no `args=()` array (e.g., `list() { :args "List secrets" "${@}" }`) were not shown in the code lens
- These are valid leaf commands with just a title and no flags/positional params
- Fix: check `func.calls_args` instead of `func.calls_args && !func.args_entries.is_empty()`

## Test plan

- [x] Added `test_code_lens_no_args_leaf` integration test
- [x] Existing code lens tests still pass (3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)