### PR TITLE
fix: build .so on bookworm + add musl build for Alpine

### DIFF
--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -64,7 +64,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
       - name: Validate and make executables
         run: |
-          for f in out/minifier out/shdoc out/libargsh.so out/argsh-lsp out/argsh-lint out/argsh-dap; do
+          for f in out/minifier out/shdoc out/libargsh.so out/libargsh-musl.so out/argsh-lsp out/argsh-lint out/argsh-dap; do
             if [[ ! -f "${f}" ]]; then
               echo "Missing expected artifact: ${f}" >&2
               exit 1
@@ -572,6 +572,7 @@ jobs:
 
           for arch in amd64 arm64; do
             cp "artifacts/binaries-linux-${arch}/libargsh.so" "release/argsh-linux-${arch}.so"
+            cp "artifacts/binaries-linux-${arch}/libargsh-musl.so" "release/argsh-linux-musl-${arch}.so"
             cp "artifacts/binaries-linux-${arch}/minifier"    "release/minifier-linux-${arch}"
             cp "artifacts/binaries-linux-${arch}/shdoc"       "release/shdoc-linux-${arch}"
             cp "artifacts/argsh-so-linux-${arch}/argsh-so" "release/argsh-so-linux-${arch}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN cargo build --release
 # -fuse-ld=lld resolves to system lld on all architectures.
 # (-Clinker-features=-lld would be cleaner but is only stable on x86_64.)
 # See: https://github.com/rust-lang/rust/issues/38238
-# Build on bookworm (glibc 2.36) for maximum compatibility.
-# cdylib (.so) cannot use musl (no shared library support), so we use the
-# oldest supported glibc to avoid "GLIBC_X.XX not found" on older hosts.
+# Build on bookworm (glibc 2.36) for maximum glibc compatibility.
 FROM rust:1-slim-bookworm AS builtin-build
 RUN apt-get update && apt-get install -y --no-install-recommends lld && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
@@ -44,6 +42,13 @@ WORKDIR /build
 COPY builtin/ .
 RUN cargo build --release
 
+# Musl build for Alpine — cdylib works with -C target-feature=-crt-static.
+FROM rust:alpine AS builtin-build-musl
+RUN apk add --no-cache lld
+WORKDIR /build
+COPY builtin/ .
+RUN RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=lld" cargo build --release
+
 # argsh-lsp / argsh-lint — LSP server + CLI linter (share the same crate).
 FROM rust:1-slim-trixie AS lsp-build
 WORKDIR /build
@@ -55,6 +60,7 @@ FROM scratch AS artifacts
 COPY --from=minifier-build /build/target/release/minifier /minifier
 COPY --from=shdoc-build /build/target/release/shdoc /shdoc
 COPY --from=builtin-build /build/target/release/libargsh.so /libargsh.so
+COPY --from=builtin-build-musl /build/target/release/libargsh.so /libargsh-musl.so
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lsp /argsh-lsp
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-lint /argsh-lint
 COPY --from=lsp-build /build/crates/argsh-lsp/target/release/argsh-dap /argsh-dap

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,14 @@ COPY builtin/ .
 RUN cargo build --release
 
 # Musl build for Alpine — cdylib works with -C target-feature=-crt-static.
-FROM rust:alpine AS builtin-build-musl
+FROM rust:1-alpine AS builtin-build-musl
 RUN apk add --no-cache lld
+# Symlink system lld over rust-lld (same workaround as glibc build — colon
+# symbols in export_name break rust-lld's version script parser).
+RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
+ARG CARGO_PROFILE_RELEASE_STRIP
+ARG CARGO_PROFILE_RELEASE_LTO
+ARG CARGO_PROFILE_RELEASE_PANIC
 WORKDIR /build
 COPY builtin/ .
 RUN RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=lld" cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,12 +48,14 @@ RUN apk add --no-cache lld
 # Symlink system lld over rust-lld (same workaround as glibc build — colon
 # symbols in export_name break rust-lld's version script parser).
 RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
+ARG RUSTFLAGS
 ARG CARGO_PROFILE_RELEASE_STRIP
 ARG CARGO_PROFILE_RELEASE_LTO
 ARG CARGO_PROFILE_RELEASE_PANIC
+ENV RUSTFLAGS="${RUSTFLAGS} -C target-feature=-crt-static -C link-arg=-fuse-ld=lld"
 WORKDIR /build
 COPY builtin/ .
-RUN RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=lld" cargo build --release
+RUN cargo build --release
 
 # argsh-lsp / argsh-lint — LSP server + CLI linter (share the same crate).
 FROM rust:1-slim-trixie AS lsp-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,10 @@ RUN cargo build --release
 # -fuse-ld=lld resolves to system lld on all architectures.
 # (-Clinker-features=-lld would be cleaner but is only stable on x86_64.)
 # See: https://github.com/rust-lang/rust/issues/38238
-FROM rust:1-slim-trixie AS builtin-build
+# Build on bookworm (glibc 2.36) for maximum compatibility.
+# cdylib (.so) cannot use musl (no shared library support), so we use the
+# oldest supported glibc to avoid "GLIBC_X.XX not found" on older hosts.
+FROM rust:1-slim-bookworm AS builtin-build
 RUN apt-get update && apt-get install -y --no-install-recommends lld && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /usr/bin/ld.lld "$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/host/{print $2}')/bin/gcc-ld/ld.lld"
 ARG RUSTFLAGS

--- a/libraries/main.sh
+++ b/libraries/main.sh
@@ -153,7 +153,12 @@ argsh::builtin::download() {
     return 1
   }
 
-  local _asset="argsh-linux-${_arch}.so"
+  # Detect libc: musl systems (Alpine) need the musl-linked .so
+  local _libc=""
+  if ldd --version 2>&1 | grep -qi musl; then
+    _libc="-musl"
+  fi
+  local _asset="argsh-linux${_libc}-${_arch}.so"
   # Download to a temp file alongside the destination, then atomically move
   # into place. This avoids two failure modes:
   #   1. A partially-downloaded .so being left at the destination on network

--- a/libraries/main.sh
+++ b/libraries/main.sh
@@ -155,7 +155,7 @@ argsh::builtin::download() {
 
   # Detect libc: musl systems (Alpine) need the musl-linked .so
   local _libc=""
-  if ldd --version 2>&1 | grep -qi musl; then
+  if command -v ldd &>/dev/null && ldd --version 2>&1 | grep -qi musl; then
     _libc="-musl"
   fi
   local _asset="argsh-linux${_libc}-${_arch}.so"


### PR DESCRIPTION
## Problem

`argsh builtin update` fails on Ubuntu 22.04:
```
GLIBC_2.39 not found (required by argsh.so)
```

Also, Alpine users couldn't use builtins at all since glibc `.so` doesn't load in musl bash.

## Solution

**Two .so builds per architecture:**

| Variant | Base | Libc | Compatible with |
|---------|------|------|-----------------|
| `libargsh.so` | bookworm | glibc 2.36 | Ubuntu 22.04+, Debian 12+, Fedora, etc. |
| `libargsh-musl.so` | Alpine | musl | Alpine Linux |

## Changes

- `Dockerfile`: builtin-build uses `rust:1-slim-bookworm` (was trixie)
- `Dockerfile`: new `builtin-build-musl` stage using `rust:alpine`
- Artifacts stage exports both variants
- TODO: `argsh builtin update` auto-detects glibc/musl and downloads the right one

🤖 Generated with [Claude Code](https://claude.com/claude-code)