### PR TITLE
fix: don't export ARGSH_SOURCE from Docker entrypoint

### DIFF
--- a/.docker/docker-entrypoint.sh
+++ b/.docker/docker-entrypoint.sh
@@ -9,8 +9,9 @@
 # :usage. This entrypoint just forwards to argsh so the container and the
 # host launcher share one source of truth.
 set -euo pipefail
-: "${ARGSH_SOURCE:="argsh"}"
-export ARGSH_SOURCE
+# Set ARGSH_SOURCE for this invocation only — don't export it into child
+# processes (bats tests, user scripts) where it would interfere with
+# standalone-vs-sourced detection guards.
 # Use absolute path — /usr/local/sbin may shadow argsh when PATH_BIN
 # is mounted there (it comes before /usr/local/bin on PATH).
-exec /usr/local/bin/argsh "${@}"
+ARGSH_SOURCE="${ARGSH_SOURCE:-argsh}" exec /usr/local/bin/argsh "${@}"


### PR DESCRIPTION
## Problem

The Docker entrypoint exported `ARGSH_SOURCE=argsh` globally. This leaked into child processes like `bats`, causing standalone guards in user scripts to misfire:

```bash
# This guard checks if the file is being sourced AND ARGSH_SOURCE is empty
[[ "${0}" != "${BASH_SOURCE[0]}" && -z "${ARGSH_SOURCE:-}" ]] || main::* "${@}"
```

Inside Docker, `ARGSH_SOURCE=argsh` → `-z` fails → guard fires → `main::*` runs in test context → exit 127 (builtins not loaded).

## Fix

Use command-prefix assignment instead of export:

```bash
# Before: exported to all child processes
export ARGSH_SOURCE
exec /usr/local/bin/argsh "${@}"

# After: set only for the argsh process
ARGSH_SOURCE="${ARGSH_SOURCE:-argsh}" exec /usr/local/bin/argsh "${@}"
```

## Test plan

- [ ] `argsh test` works inside Docker without workarounds
- [ ] `argsh status` still shows correct source name

🤖 Generated with [Claude Code](https://claude.com/claude-code)