### PR TITLE
fix: detect extensionless argsh scripts as shellscript

### DIFF
--- a/vscode-argsh/package-lock.json
+++ b/vscode-argsh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argsh",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argsh",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "vscode-languageclient": "^9.0.0"
       },

--- a/vscode-argsh/package.json
+++ b/vscode-argsh/package.json
@@ -13,7 +13,7 @@
   },
   "icon": "icon.png",
   "categories": ["Programming Languages", "Linters", "Debuggers", "Snippets"],
-  "activationEvents": ["onLanguage:shellscript", "onDebugResolve:argsh", "onStartupFinished"],
+  "activationEvents": ["onLanguage:shellscript", "onDebugResolve:argsh"],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [

--- a/vscode-argsh/package.json
+++ b/vscode-argsh/package.json
@@ -2,7 +2,7 @@
   "name": "argsh",
   "displayName": "argsh",
   "description": "Language support, linting, and debugging for argsh — structured Bash scripting framework",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "arg-sh",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "icon": "icon.png",
   "categories": ["Programming Languages", "Linters", "Debuggers", "Snippets"],
-  "activationEvents": ["onLanguage:shellscript", "onDebugResolve:argsh"],
+  "activationEvents": ["onLanguage:shellscript", "onDebugResolve:argsh", "onStartupFinished"],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -75,6 +75,12 @@
         }
       ]
     },
+    "languages": [
+      {
+        "id": "shellscript",
+        "firstLine": "^#!.*\\bargsh\\b"
+      }
+    ],
     "grammars": [
       {
         "scopeName": "source.shell.argsh",

--- a/vscode-argsh/src/extension.ts
+++ b/vscode-argsh/src/extension.ts
@@ -150,6 +150,23 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
+  // Force-detect extensionless argsh scripts as shellscript.
+  // VSCode may misdetect them as "ini" or "plaintext" without a .sh extension.
+  const setArgshLanguage = (doc: vscode.TextDocument) => {
+    if (doc.languageId === 'shellscript') return;
+    if (doc.lineCount === 0) return;
+    const firstLine = doc.lineAt(0).text;
+    if (/^#!.*\bargsh\b/.test(firstLine)) {
+      vscode.languages.setTextDocumentLanguage(doc, 'shellscript');
+    }
+  };
+  // Check all currently open documents
+  vscode.workspace.textDocuments.forEach(setArgshLanguage);
+  // Check newly opened documents
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(setArgshLanguage)
+  );
+
   if (!config.get<boolean>('lsp.enabled', true)) {
     return;
   }

--- a/vscode-argsh/src/extension.ts
+++ b/vscode-argsh/src/extension.ts
@@ -154,10 +154,12 @@ export function activate(context: vscode.ExtensionContext) {
   // VSCode may misdetect them as "ini" or "plaintext" without a .sh extension.
   const setArgshLanguage = (doc: vscode.TextDocument) => {
     if (doc.languageId === 'shellscript') return;
-    if (doc.lineCount === 0) return;
     const firstLine = doc.lineAt(0).text;
     if (/^#!.*\bargsh\b/.test(firstLine)) {
-      vscode.languages.setTextDocumentLanguage(doc, 'shellscript');
+      vscode.languages.setTextDocumentLanguage(doc, 'shellscript').then(
+        undefined,
+        () => {} // ignore errors (document may have been closed)
+      );
     }
   };
   // Check all currently open documents


### PR DESCRIPTION
## Problem

Files without `.sh` extension but with `#!/usr/bin/env argsh` shebang are misdetected as `ini` or `plaintext` by VSCode, preventing the argsh LSP from activating.

## Fix

1. **`package.json` `firstLine` pattern** — tells VSCode that files with argsh shebang are shellscript
2. **`extension.ts` force-set** — `vscode.languages.setTextDocumentLanguage()` on open when shebang contains `argsh`
3. **`onStartupFinished`** — catches files opened before extension loads

Bumps extension to v0.2.3.

Closes #119

## Test plan

- [ ] Open extensionless file with `#!/usr/bin/env argsh` → gets detected as shellscript
- [ ] Argsh LSP activates (code lens, diagnostics visible)
- [ ] Files already identified as shellscript are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)