### PR TITLE
feat: show inherited marker for :^ fields in LSP

### DIFF
--- a/crates/argsh-lsp/coverage.json
+++ b/crates/argsh-lsp/coverage.json
@@ -142,16 +142,16 @@
     },
     {
       "file": "crates/argsh-lsp/src/hover.rs",
-      "percent_covered": "63.74",
-      "covered_lines": "457",
-      "total_lines": "717",
+      "percent_covered": "63.76",
+      "covered_lines": "461",
+      "total_lines": "723",
       "excluded_lines": "0"
     },
     {
       "file": "crates/argsh-lsp/src/preview.rs",
-      "percent_covered": "24.81",
-      "covered_lines": "132",
-      "total_lines": "532",
+      "percent_covered": "24.68",
+      "covered_lines": "134",
+      "total_lines": "543",
       "excluded_lines": "0"
     },
     {
@@ -162,12 +162,12 @@
       "excluded_lines": "0"
     }
   ],
-  "percent_covered": "81.37",
-  "covered_lines": 6543,
-  "total_lines": 8041,
+  "percent_covered": "81.27",
+  "covered_lines": 6549,
+  "total_lines": 8058,
   "excluded_lines": 0,
   "percent_low": 25,
   "percent_high": 75,
   "command": "cargo-test+llvm-cov",
-  "date": "2026-04-20 12:27:43"
+  "date": "2026-04-20 18:29:34"
 }

--- a/crates/argsh-lsp/src/hover.rs
+++ b/crates/argsh-lsp/src/hover.rs
@@ -496,6 +496,9 @@ fn hover_array_overview(
                     if field.hidden {
                         desc.push_str(" *(hidden)*");
                     }
+                    if field.is_inherited {
+                        desc.push_str(" *(inherited)*");
+                    }
 
                     md.push_str(&format!("| {} | {} | {} |\n", flag_str, type_str, desc));
                 } else {
@@ -633,6 +636,9 @@ fn render_args_entry_detail(entry: &ArgsArrayEntry) -> Hover {
     ));
     if field.hidden {
         md.push_str("\n*Hidden: yes*");
+    }
+    if field.is_inherited {
+        md.push_str("\n*Inherited: yields to non-`:^` duplicates*");
     }
 
     Hover {

--- a/crates/argsh-lsp/src/preview.rs
+++ b/crates/argsh-lsp/src/preview.rs
@@ -285,12 +285,16 @@ pre {{
                     } else {
                         "no"
                     };
+                    let mut desc = html_escape(&entry.description);
+                    if field.is_inherited {
+                        desc.push_str(" <span style=\"color:var(--text-dim);font-style:italic\">inherited</span>");
+                    }
                     html.push_str(&format!(
                         "<tr><td>{}</td><td><span class=\"type-badge\">{}</span></td><td>{}</td><td>{}</td></tr>\n",
                         flag_str,
                         html_escape(&type_str),
                         req_str,
-                        html_escape(&entry.description)
+                        desc
                     ));
                 }
             }
@@ -532,6 +536,9 @@ fn build_docgen_yaml(analysis: &DocumentAnalysis, _content: &str) -> String {
                     }
                     if field.hidden {
                         yaml.push_str("      hidden: true\n");
+                    }
+                    if field.is_inherited {
+                        yaml.push_str("      inherited: true\n");
                     }
                     if let Some(ref short) = field.short {
                         yaml.push_str(&format!("      short: {}\n", short));

--- a/crates/argsh-lsp/src/preview.rs
+++ b/crates/argsh-lsp/src/preview.rs
@@ -374,9 +374,13 @@ pre {{
                             format!("--{}", html_escape(&field.display_name))
                         };
                         let typ = format_type(field, entry.is_array);
+                        let mut desc = html_escape(&entry.description);
+                        if field.is_inherited {
+                            desc.push_str(" <span style=\"color:var(--text-dim);font-style:italic\">inherited</span>");
+                        }
                         html.push_str(&format!(
                             "<tr><td>{}</td><td><span class=\"type-badge\">{}</span></td><td>{}</td></tr>\n",
-                            flag, html_escape(&typ), html_escape(&entry.description)
+                            flag, html_escape(&typ), desc
                         ));
                     }
                 }

--- a/vscode-argsh/package-lock.json
+++ b/vscode-argsh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argsh",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argsh",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "vscode-languageclient": "^9.0.0"
       },

--- a/vscode-argsh/package-lock.json
+++ b/vscode-argsh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argsh",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argsh",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "vscode-languageclient": "^9.0.0"
       },

--- a/vscode-argsh/package.json
+++ b/vscode-argsh/package.json
@@ -2,7 +2,7 @@
   "name": "argsh",
   "displayName": "argsh",
   "description": "Language support, linting, and debugging for argsh — structured Bash scripting framework",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "arg-sh",
   "repository": {
     "type": "git",

--- a/vscode-argsh/package.json
+++ b/vscode-argsh/package.json
@@ -2,7 +2,7 @@
   "name": "argsh",
   "displayName": "argsh",
   "description": "Language support, linting, and debugging for argsh — structured Bash scripting framework",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "arg-sh",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "icon": "icon.png",
   "categories": ["Programming Languages", "Linters", "Debuggers", "Snippets"],
-  "activationEvents": ["onLanguage:shellscript", "onDebugResolve:argsh"],
+  "activationEvents": ["onLanguage:shellscript", "onDebugResolve:argsh", "onStartupFinished"],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -75,6 +75,12 @@
         }
       ]
     },
+    "languages": [
+      {
+        "id": "shellscript",
+        "firstLine": "^#!.*\\bargsh\\b"
+      }
+    ],
     "grammars": [
       {
         "scopeName": "source.shell.argsh",

--- a/vscode-argsh/src/extension.ts
+++ b/vscode-argsh/src/extension.ts
@@ -150,6 +150,23 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
+  // Force-detect extensionless argsh scripts as shellscript.
+  // VSCode may misdetect them as "ini" or "plaintext" without a .sh extension.
+  const setArgshLanguage = (doc: vscode.TextDocument) => {
+    if (doc.languageId === 'shellscript') return;
+    if (doc.lineCount === 0) return;
+    const firstLine = doc.lineAt(0).text;
+    if (/^#!.*\bargsh\b/.test(firstLine)) {
+      vscode.languages.setTextDocumentLanguage(doc, 'shellscript');
+    }
+  };
+  // Check all currently open documents
+  vscode.workspace.textDocuments.forEach(setArgshLanguage);
+  // Check newly opened documents
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(setArgshLanguage)
+  );
+
   if (!config.get<boolean>('lsp.enabled', true)) {
     return;
   }


### PR DESCRIPTION
## Summary

`:^` inherited fields are now visually marked across all LSP output surfaces.

| Surface | Display |
|---------|---------|
| Hover on args entry | *Inherited: yields to non-`:^` duplicates* |
| Help text hover | *(inherited)* badge in description |
| HTML preview | `inherited` in italics |
| YAML export | `inherited: true` field |

## Example

Hovering over `'domain|:^'` now shows:

```
**--domain** `string`

Domain to use

*Required: no*
*Inherited: yields to non-:^ duplicates*
```

Bumps extension to v0.2.4.

## Test plan

- [ ] Hover on `:^` field shows inherited info
- [ ] Preview dashboard shows inherited in description
- [ ] YAML export includes `inherited: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)