### PR TITLE
fix: coverage build image + add plugins to docs sidebar

### DIFF
--- a/.bin/argsh
+++ b/.bin/argsh
@@ -229,18 +229,17 @@ coverage::builtin() {
     rustup component add llvm-tools
   }
 
-  # Build coverage-instrumented .so inside Docker (rust:1-slim-trixie) to ensure
-  # glibc compatibility with the argsh Docker image (also Debian trixie).
+  # Build coverage-instrumented .so inside Docker (rust:1-slim-bookworm).
+  # Must match the Dockerfile's builtin-build stage to use the same lld version.
+  # Using trixie here breaks because its lld regressed on colon-prefixed symbols.
   # Mount sources at the same absolute path so llvm-cov finds them on the host.
-  # Install system lld and symlink it over rust-lld — both GNU ld and rust-lld
-  # choke on colon-prefixed export_name symbols. System lld handles them.
   # See: https://github.com/rust-lang/rust/issues/38238
   echo "Building with coverage instrumentation (via Docker)..."
   local _uid; _uid="$(id -u):$(id -g)"
   docker run --rm \
     -v "${PATH_BASE}/builtin:${PATH_BASE}/builtin" \
     -w "${PATH_BASE}/builtin" \
-    rust:1-slim-trixie \
+    rust:1-slim-bookworm \
     bash -c "apt-get update -qq && apt-get install -y -qq lld >/dev/null 2>&1 && \
       ln -sf /usr/bin/ld.lld \"\$(rustc --print sysroot)/lib/rustlib/\$(rustc -vV | awk '/host/{print \$2}')/bin/gcc-ld/ld.lld\" && \
       RUSTFLAGS='-C instrument-coverage -C link-arg=-fuse-ld=lld' \


### PR DESCRIPTION
## Summary

- **CI fix**: Coverage build was using `rust:1-slim-trixie` whose `lld` regressed on colon-prefixed `export_name` symbols. Switched to `rust:1-slim-bookworm` to match the Dockerfile's `builtin-build` stage.
- **Docs**: Plugin pages (overview, authoring, jaml) were created but never registered in `sidebars.js`. Added Plugins as a top-level section in the docs navigation.

## Test plan
- [ ] Coverage job passes without retries
- [ ] Plugins section visible at arg.sh with overview, authoring, and jaml pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)