### PR TITLE
fix(args): skip required-flag check for positional fields

### DIFF
--- a/libraries/args.bats
+++ b/libraries/args.bats
@@ -2935,3 +2935,35 @@ source "${PATH_FIXTURES}/fmt.sh"
   assert "${status}" -eq 0
   contains 'port=8080' stdout
 }
+
+# -----------------------------------------------------------------------------
+# Issue #133: :! on positional fields should not trigger "missing required flag"
+
+@test "attrs: positional with required modifier does not error as missing flag" {
+  (
+    local name
+    local -a args=(
+      'name:!' "A required positional"
+    )
+    :args "Positional required test" "hello"
+    echo "name=${name}"
+  ) >"${stdout}" 2>"${stderr}" || status=$?
+
+  assert "${status}" -eq 0
+  is_empty stderr
+  contains 'name=hello' stdout
+}
+
+@test "attrs: error: positional with required modifier still errors when missing" {
+  (
+    local name
+    local -a args=(
+      'name:!' "A required positional"
+    )
+    :args "Positional required test"
+  ) >"${stdout}" 2>"${stderr}" || status=$?
+
+  assert "${status}" -eq 2
+  is_empty stdout
+  contains "missing required argument" stderr
+}

--- a/libraries/args.bats
+++ b/libraries/args.bats
@@ -2941,7 +2941,7 @@ source "${PATH_FIXTURES}/fmt.sh"
 
 @test "attrs: positional with required modifier does not error as missing flag" {
   (
-    local name
+    local name=""
     local -a args=(
       'name:!' "A required positional"
     )

--- a/libraries/args.sh
+++ b/libraries/args.sh
@@ -659,7 +659,9 @@ if ! (( ARGSH_BUILTIN )); then
     fi
 
     # is it required? was it matched?
-    if (( attrs[6] )) && [[ -z ${match[${args[i]}]:-} ]]; then
+    # skip positionals (no '|' means no flag aliases) — they are validated
+    # by position, not by flag lookup
+    if (( attrs[6] )) && [[ ${args[i]} == *"|"* ]] && [[ -z ${match[${args[i]}]:-} ]]; then
       :args::error_usage "missing required flag: ${args[i]/|*}"
     fi
   done

--- a/libraries/args.sh
+++ b/libraries/args.sh
@@ -468,25 +468,25 @@ if ! (( ARGSH_BUILTIN )); then
   while (( ${#cli[@]} )); do
     # positional
     if [[ ${cli[0]:0:1} != "-" ]]; then
-      local name value
+      local _pos_name _pos_value
       i="$(:args::field_positional "${positional_index}")" ||
         :args::error_usage "too many arguments: ${cli[0]}"
 
       field="${args[i]}"
-      name="$(args::field_name "${field}")"
-      value="$(:args::field_value "${cli[0]}")" || exit "${?}"
+      _pos_name="$(args::field_name "${field}")"
+      _pos_value="$(:args::field_value "${cli[0]}")" || exit "${?}"
 
       # shellcheck disable=SC2155
-      local -n ref="${name}"
-      if is::array "${name}"; then
+      local -n ref="${_pos_name}"
+      if is::array "${_pos_name}"; then
         (( first )) || {
           ref=()
           first=1
         }
-        ref+=("${value}")
+        ref+=("${_pos_value}")
       else
         # shellcheck disable=SC2178
-        ref="${value}"
+        ref="${_pos_value}"
       fi
       cli=("${cli[@]:1}")
       (( ++positional_index ))


### PR DESCRIPTION
## Summary
In pure bash :args, `:!` on a positional field triggered "missing required flag" because check_required_flags treated all fields equally. Now positional fields (without `|`) skip the required-flag check since they're inherently required by position.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)