### PR TITLE
fix: derive ARGSH_VERSION from git when running from source

### DIFF
--- a/libraries/main.bats
+++ b/libraries/main.bats
@@ -227,6 +227,33 @@ declare -gi ARGSH_BUILTIN="${ARGSH_BUILTIN:-0}"
   contains "test-ver" stdout
 }
 
+@test "shebang: --version derives from git when ARGSH_VERSION unset" {
+  # Unset ARGSH_VERSION so the git-describe fallback triggers
+  (
+    unset ARGSH_VERSION
+    # Re-source main.sh to trigger the fallback logic
+    source "${BATS_TEST_DIRNAME}/main.sh"
+    argsh::shebang --version
+  ) >"${stdout}" 2>"${stderr}" || status=$?
+
+  assert "${status}" -eq 0
+  # Must not say "unknown" — git describe should have produced a tag/hash
+  ! command grep -q "unknown" "${stdout}"
+  contains "argsh " stdout
+}
+
+@test "argsh::status outputs version from git when ARGSH_VERSION unset" {
+  (
+    unset ARGSH_VERSION
+    source "${BATS_TEST_DIRNAME}/main.sh"
+    ARGSH_BUILTIN=0 argsh::status
+  ) >"${stdout}" 2>"${stderr}" || status=$?
+
+  assert "${status}" -eq 0
+  ! command grep -q "argsh unknown" "${stdout}"
+  contains "argsh " stdout
+}
+
 # ---------------------------------------------------------------------------
 # Subcommand handler tests — verify dispatch reaches the handler and that
 # discover_files is available (regression: https://... was

--- a/libraries/main.sh
+++ b/libraries/main.sh
@@ -20,11 +20,12 @@ import github
 
 # Derive ARGSH_VERSION and ARGSH_COMMIT_SHA from git when running from source
 # (i.e. not from the minified release where these are baked in at build time).
+# Use -C to target the argsh repo, not the caller's working directory.
 if [[ -z "${ARGSH_VERSION:-}" || "${ARGSH_VERSION:-}" == "unknown" ]]; then
-  ARGSH_VERSION="$(git describe --tags --dirty 2>/dev/null)" || ARGSH_VERSION="unknown"
+  ARGSH_VERSION="$(git -C "${BASH_SOURCE[0]%/*}" describe --tags --always --dirty 2>/dev/null)" || ARGSH_VERSION="unknown"
 fi
 if [[ -z "${ARGSH_COMMIT_SHA:-}" || "${ARGSH_COMMIT_SHA:-}" == "unknown" ]]; then
-  ARGSH_COMMIT_SHA="$(git rev-parse --short HEAD 2>/dev/null)" || ARGSH_COMMIT_SHA="unknown"
+  ARGSH_COMMIT_SHA="$(git -C "${BASH_SOURCE[0]%/*}" rev-parse --short HEAD 2>/dev/null)" || ARGSH_COMMIT_SHA="unknown"
 fi
 
 # @description Try loading argsh native builtins (.so).

--- a/libraries/main.sh
+++ b/libraries/main.sh
@@ -18,6 +18,15 @@ import github
 # both forms; `declare -F` would miss builtin-loaded :usage.
 [[ -n "$(type -t :usage 2>/dev/null)" ]] || import args
 
+# Derive ARGSH_VERSION and ARGSH_COMMIT_SHA from git when running from source
+# (i.e. not from the minified release where these are baked in at build time).
+if [[ -z "${ARGSH_VERSION:-}" || "${ARGSH_VERSION:-}" == "unknown" ]]; then
+  ARGSH_VERSION="$(git describe --tags --dirty 2>/dev/null)" || ARGSH_VERSION="unknown"
+fi
+if [[ -z "${ARGSH_COMMIT_SHA:-}" || "${ARGSH_COMMIT_SHA:-}" == "unknown" ]]; then
+  ARGSH_COMMIT_SHA="$(git rev-parse --short HEAD 2>/dev/null)" || ARGSH_COMMIT_SHA="unknown"
+fi
+
 # @description Try loading argsh native builtins (.so).
 # Delegates search to __argsh_try_builtin() (defined in args.sh) to avoid
 # duplicating the search logic. Only adds explicit-path handling.


### PR DESCRIPTION
## Summary
When ARGSH_VERSION is not set or is "unknown", derive it from `git describe --tags --dirty`. Allows `argsh --argsh` and `argsh status` to show the version when running from source without Docker.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)