### PR TITLE
test(builtin): add unit tests for OCI auth and client

### DIFF
--- a/builtin/src/oci/auth.rs
+++ b/builtin/src/oci/auth.rs
@@ -77,6 +77,49 @@ impl AuthChallenge {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_standard_bearer_challenge() {
+        let h = r#"Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:arg-sh/libs/data:pull""#;
+        let c = AuthChallenge::from_header(h).unwrap();
+        assert_eq!(c.realm, "https://ghcr.io/token");
+        assert_eq!(c.service, "ghcr.io");
+        assert_eq!(c.scope, "repository:arg-sh/libs/data:pull");
+    }
+
+    #[test]
+    fn parse_challenge_with_extra_whitespace() {
+        let h = r#"Bearer  realm="https://example.com/token" , service="example.com" , scope="repo:pull""#;
+        let c = AuthChallenge::from_header(h).unwrap();
+        assert_eq!(c.realm, "https://example.com/token");
+    }
+
+    #[test]
+    fn parse_challenge_with_comma_in_scope() {
+        let h = r#"Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:name:push,pull""#;
+        let c = AuthChallenge::from_header(h).unwrap();
+        assert_eq!(c.scope, "repository:name:push,pull");
+    }
+
+    #[test]
+    fn reject_non_bearer_scheme() {
+        assert!(AuthChallenge::from_header(r#"Basic realm="example""#).is_none());
+    }
+
+    #[test]
+    fn reject_missing_fields() {
+        assert!(AuthChallenge::from_header(r#"Bearer realm="https://example.com/token",service="example.com""#).is_none());
+    }
+
+    #[test]
+    fn reject_empty_header() {
+        assert!(AuthChallenge::from_header("").is_none());
+    }
+}
+
 /// Load the base64-encoded `user:pass` credential for `domain` from
 /// `~/.docker/config.json`.
 pub(crate) fn docker_basic_auth(domain: &str) -> Option<String> {

--- a/builtin/src/oci/client.rs
+++ b/builtin/src/oci/client.rs
@@ -386,3 +386,73 @@ fn parse_manifest(val: &serde_json::Value) -> Result<Manifest, BoxErr> {
         layers,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_simple_registry() {
+        let c = OciClient::new("ghcr.io", "mylib", "latest").unwrap();
+        assert_eq!(c.url("manifests/latest"), "https://ghcr.io/v2/mylib/manifests/latest");
+    }
+
+    #[test]
+    fn url_nested_registry() {
+        let c = OciClient::new("ghcr.io/arg-sh/libs", "data", "0.1.0").unwrap();
+        assert_eq!(c.url("manifests/0.1.0"), "https://ghcr.io/v2/arg-sh/libs/data/manifests/0.1.0");
+    }
+
+    #[test]
+    fn url_trailing_slash_stripped() {
+        let c = OciClient::new("ghcr.io/arg-sh/libs/", "data", "latest").unwrap();
+        assert_eq!(c.url("blobs/sha256:abc"), "https://ghcr.io/v2/arg-sh/libs/data/blobs/sha256:abc");
+    }
+
+    #[test]
+    fn registry_host_simple() {
+        let c = OciClient::new("ghcr.io", "lib", "v1").unwrap();
+        assert_eq!(c.registry_host(), "ghcr.io");
+    }
+
+    #[test]
+    fn registry_host_nested() {
+        let c = OciClient::new("ghcr.io/arg-sh/libs", "lib", "v1").unwrap();
+        assert_eq!(c.registry_host(), "ghcr.io");
+    }
+
+    #[test]
+    fn parse_oci_manifest() {
+        let json: serde_json::Value = serde_json::from_str(r#"{
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": { "mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:abc123", "size": 2 },
+            "layers": [{ "mediaType": "application/octet-stream", "digest": "sha256:def456", "size": 1024 }]
+        }"#).unwrap();
+        let m = parse_manifest(&json).unwrap();
+        assert_eq!(m.media_type.unwrap(), "application/vnd.oci.image.manifest.v1+json");
+        assert_eq!(m.config.digest, "sha256:abc123");
+        assert_eq!(m.layers.len(), 1);
+        assert_eq!(m.layers[0].size, 1024);
+    }
+
+    #[test]
+    fn parse_manifest_missing_layers() {
+        let json: serde_json::Value = serde_json::from_str(r#"{ "config": { "digest": "sha256:abc", "size": 0 } }"#).unwrap();
+        assert!(parse_manifest(&json).is_err());
+    }
+
+    #[test]
+    fn parse_descriptor_missing_digest() {
+        let json: serde_json::Value = serde_json::from_str(r#"{ "size": 0 }"#).unwrap();
+        assert!(parse_descriptor(&json).is_err());
+    }
+
+    #[test]
+    fn parse_descriptor_defaults() {
+        let json: serde_json::Value = serde_json::from_str(r#"{ "digest": "sha256:abc" }"#).unwrap();
+        let d = parse_descriptor(&json).unwrap();
+        assert_eq!(d.media_type, "application/octet-stream");
+        assert_eq!(d.size, 0);
+        assert!(d.annotations.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
Unit tests for AuthChallenge parsing (6 tests), OCI URL construction (3 tests), manifest/descriptor parsing (4 tests). Requires cargo test CI support.

Partial fix for #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)