### PR TITLE
docs: update plugin, env var, and lint docs for recent features

### DIFF
--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -549,7 +549,7 @@ jobs:
           argsh coverage minifier
           argsh coverage shdoc
           argsh coverage lsp
-          argsh minify libraries -t argsh.min.tmpl -o argsh.min.sh
+          argsh minify
         env:
           GIT_COMMIT_SHA: ${{ github.sha }}
           GIT_VERSION: ${{ github.ref_name }}

--- a/docs/development/fundamentals/lint.mdx
+++ b/docs/development/fundamentals/lint.mdx
@@ -101,6 +101,7 @@ Common flags (names chosen to match shellcheck):
 | `-i LIST`, `--include=LIST`| Only enable these codes                             |
 | `-S SEV`, `--severity=SEV` | Minimum severity: `error`, `warning`, `info`, `style` |
 | `-C WHEN`, `--color=WHEN`  | `auto`, `always`, `never`                           |
+| `-W N`, `--wiki-link-count=N` | Show wiki links for the first N occurrences of each diagnostic code (default `0`). Useful for discovering the [diagnostic reference pages](../../diagnostics/ag001.mdx). |
 | `--no-resolve`             | Skip cross-file import resolution (faster)          |
 
 Reading from stdin:

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -126,6 +126,30 @@ argsh test   # container sees MY_TOKEN=secret, DEBUG=1
 
 This is useful for passing secrets, feature flags, or tool configuration without modifying argsh itself. Works in `.envrc`, CI, and MCP contexts.
 
+### ARGSH_LIB_REGISTRY
+
+Override the default OCI registry for plugin libraries. Defaults to `ghcr.io/arg-sh/libs`.
+
+```bash
+export ARGSH_LIB_REGISTRY="harbor.mycompany.com/argsh"
+```
+
+### ARGSH_OCI_CONNECT_TIMEOUT
+
+OCI client connection timeout in seconds. Defaults to `10`.
+
+```bash
+export ARGSH_OCI_CONNECT_TIMEOUT=5
+```
+
+### ARGSH_OCI_IO_TIMEOUT
+
+OCI client read/write timeout in seconds. Defaults to `30`.
+
+```bash
+export ARGSH_OCI_IO_TIMEOUT=60
+```
+
 ## Read-Only Variables
 
 These are set by argsh at runtime and should not be modified.

--- a/docs/plugins/authoring.mdx
+++ b/docs/plugins/authoring.mdx
@@ -39,7 +39,7 @@ depends:
 | Field | Required | Description |
 | ----- | -------- | ----------- |
 | `name` | yes | Plugin name. Must match `[a-zA-Z0-9_-]+`. |
-| `version` | yes | Semver version (`x.y.z`, optional `-pre` suffix). Required for publishing. |
+| `version` | for publish | Semver version (`x.y.z`, optional `-pre` suffix). Required for `argsh publish`, optional otherwise. |
 | `description` | no | Short description of the plugin. |
 | `requires.argsh` | no | Semver constraint for the minimum argsh version (e.g. `>=0.9.0`). On `argsh add`, a warning is printed if the installed argsh does not satisfy the constraint. |
 | `depends` | no | List of plugin dependencies. Each entry is a plugin name or `name@version`. Dependencies are auto-installed when the plugin is added via `argsh add`. |

--- a/docs/plugins/authoring.mdx
+++ b/docs/plugins/authoring.mdx
@@ -4,7 +4,7 @@ description: 'How to create an argsh plugin library.'
 
 # Authoring Plugins
 
-Create reusable libraries that others can install via `argsh lib add`.
+Create reusable libraries that others can install via `argsh add`.
 
 ## Structure
 
@@ -29,7 +29,20 @@ version: 0.1.0
 description: What this library does
 requires:
   argsh: ">=0.9.0"
+depends:
+  - jaml
+  - otherlib@0.2.0
 ```
+
+### Fields
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `name` | yes | Plugin name. Must match `[a-zA-Z0-9_-]+`. |
+| `version` | yes | Semver version (`x.y.z`, optional `-pre` suffix). Required for publishing. |
+| `description` | no | Short description of the plugin. |
+| `requires.argsh` | no | Semver constraint for the minimum argsh version (e.g. `>=0.9.0`). On `argsh add`, a warning is printed if the installed argsh does not satisfy the constraint. |
+| `depends` | no | List of plugin dependencies. Each entry is a plugin name or `name@version`. Dependencies are auto-installed when the plugin is added via `argsh add`. |
 
 ## Library file
 
@@ -75,9 +88,29 @@ bats mylib/mylib.bats
 
 ## Publishing
 
-Plugins are distributed via the [arg-sh/libs](https://github.com/arg-sh/libs) repository.
+Plugins are distributed as OCI artifacts via the [arg-sh/libs](https://github.com/arg-sh/libs) repository. You can also publish to your own OCI registry.
 
-To contribute a plugin:
+### Validation
+
+`argsh publish` validates your `argsh-plugin.yml` before pushing:
+
+- `name` and `version` fields must be present.
+- `name` must match `[a-zA-Z0-9_-]+`.
+- `version` must be valid semver (`x.y.z` with optional `-pre` suffix). Tags like `latest` or bare integers are rejected.
+
+### Publishing to a registry
+
+```bash
+# Publish to the default registry (ghcr.io/arg-sh/libs)
+argsh publish
+
+# Publish to a custom registry
+argsh publish --registry harbor.mycompany.com/argsh
+```
+
+Publishing requires the native builtin (`.so`) with OCI push support. Install it with `argsh builtin install` if missing.
+
+### Contributing to arg-sh/libs
 
 1. Fork `github.com/arg-sh/libs`
 2. Create your library directory with the structure above

--- a/docs/plugins/libs/jaml.mdx
+++ b/docs/plugins/libs/jaml.mdx
@@ -6,7 +6,7 @@ description: 'Structured jaml access for YAML/JSON files.'
 
 Plugin library for reading and writing structured jaml (YAML/JSON).
 
-Install: `argsh lib add jaml`
+Install: `argsh add jaml`
 
 ## jaml::get
 
@@ -91,5 +91,5 @@ jaml::merge base.yaml overlay.yaml > merged.yaml
 ## Source
 
 - Repository: [github.com/arg-sh/libs](https://github.com/arg-sh/libs)
-- Install: `argsh lib add jaml`
+- Install: `argsh add jaml`
 - Import: `import jaml`

--- a/docs/plugins/libs/shell-op.mdx
+++ b/docs/plugins/libs/shell-op.mdx
@@ -6,7 +6,7 @@ description: 'Declarative shell-operator hooks for argsh.'
 
 Plugin library for writing [shell-operator](https://github.com/flant/shell-operator) hooks with clean, typed functions.
 
-Install: `argsh lib add shell-op`
+Install: `argsh add shell-op`
 
 ## shell-op::on
 
@@ -150,5 +150,5 @@ See the [example hook](https://github.com/arg-sh/libs/blob/main/shell-op/example
 
 - Repository: [github.com/arg-sh/libs](https://github.com/arg-sh/libs)
 - Docker: `ghcr.io/arg-sh/shell-op:latest`
-- Install: `argsh lib add shell-op`
+- Install: `argsh add shell-op`
 - Import: `import shell-op`

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -5,13 +5,16 @@ sidebar_label: 'Overview'
 
 # Plugins
 
-argsh supports plugin libraries that extend its functionality beyond the core. Plugins are installed per-project and imported like any other library.
+argsh supports plugin libraries that extend its functionality beyond the core. Plugins are installed per-project and imported like any other library. No external dependencies (such as `yq`) are required — argsh parses YAML configuration files with built-in pure-Bash helpers.
 
 ## Quick start
 
 ```bash
+# Search for available plugins
+argsh search
+
 # Add a plugin
-argsh lib add jaml
+argsh add jaml
 
 # Use it
 import jaml
@@ -22,11 +25,12 @@ jaml::get config.yaml domain=.spec.cluster.domain
 
 ## How it works
 
-Plugins are distributed as OCI artifacts or GitHub release tarballs. They install to your project's `.argsh/libs/` directory and are resolved via the standard `import` system.
+Plugins are distributed as OCI artifacts or GitHub release tarballs. They install to your project's `.argsh/libs/` directory and are resolved via the standard `import` system. A lockfile (`.argsh.lock`) records the exact OCI ref and digest for each installed library, enabling reproducible installs.
 
 ```text
 myproject/
 ├── .argsh.yaml          # declares dependencies
+├── .argsh.lock          # pinned refs + digests (committed to VCS)
 ├── .argsh/
 │   └── libs/            # installed plugins (gitignored)
 │       └── jaml/
@@ -39,11 +43,52 @@ myproject/
 
 | Command | Description |
 | ------- | ----------- |
-| `argsh lib add <name>` | Install a plugin |
-| `argsh lib add <name>@<version>` | Install a specific version |
-| `argsh lib list` | List installed plugins |
-| `argsh lib remove <name>` | Remove a plugin |
-| `argsh lib install` | Install all from `.argsh.yaml` |
+| `argsh add <name>` | Install a plugin |
+| `argsh add <name>@<version>` | Install a specific version |
+| `argsh add --global <name>` | Install to the global libs directory with lockfile tracking |
+| `argsh search [filter]` | Search available plugins (substring match) |
+| `argsh list` | List installed plugins |
+| `argsh list --global` | List globally installed plugins |
+| `argsh remove <name>` | Remove a plugin |
+| `argsh remove --global <name>` | Remove a globally installed plugin |
+| `argsh install` | Install all from `.argsh.lock` (or `.argsh.yaml` if no lockfile) |
+| `argsh update` | Update all project libraries to latest versions |
+| `argsh update --global` | Update all globally installed libraries |
+| `argsh publish` | Publish the current directory as a plugin to an OCI registry |
+
+### `argsh search`
+
+Queries the GitHub API for releases from [arg-sh/libs](https://github.com/arg-sh/libs), grouped by library name with the latest version shown. An optional filter argument restricts output to matching names. Uses `GITHUB_TOKEN` / `GH_TOKEN` when available to avoid rate limits.
+
+```bash
+argsh search          # list all available plugins
+argsh search jaml     # filter by name substring
+```
+
+### `argsh add --global`
+
+Installs a plugin to the global libs directory (`${XDG_DATA_HOME:-~/.local/share}/argsh/libs`) instead of the project-local `.argsh/libs/`. Global installs are tracked in a separate lockfile at `~/.local/share/argsh/libs/.argsh-global.lock`.
+
+```bash
+argsh add --global jaml
+```
+
+### `argsh install`
+
+Installs all libraries from the lockfile (`.argsh.lock`). Each entry's OCI digest is verified during install — if a digest mismatch is detected, installation of that library fails. If no lockfile exists, falls back to reading `.argsh.yaml`.
+
+```bash
+argsh install
+```
+
+### `argsh update`
+
+Re-fetches every library at its latest version and updates the lockfile. With `--global`, updates all globally installed libraries instead.
+
+```bash
+argsh update            # update project libraries
+argsh update --global   # update global libraries
+```
 
 ## Project configuration
 
@@ -84,6 +129,6 @@ Core libraries (`is::`, `to::`, `string::`, `args`, etc.) ship with argsh and ar
 | | Core libraries | Plugins |
 | --- | --- | --- |
 | Location | `libraries/*.sh` | `.argsh/libs/` |
-| Install | Built-in | `argsh lib add` |
+| Install | Built-in | `argsh add` |
 | Docs | [Library Reference](/libraries/overview) | This section |
 | Source | [arg-sh/argsh](https://github.com/arg-sh/argsh) | [arg-sh/libs](https://github.com/arg-sh/libs) |

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -67,7 +67,7 @@ argsh search jaml     # filter by name substring
 
 ### `argsh add --global`
 
-Installs a plugin to the global libs directory (`${XDG_DATA_HOME:-~/.local/share}/argsh/libs`) instead of the project-local `.argsh/libs/`. Global installs are tracked in a separate lockfile at `${XDG_DATA_HOME:-~/.local/share}/argsh/libs/.argsh-global.lock`.
+Installs a plugin to the global libs directory (`${XDG_DATA_HOME:-$HOME/.local/share}/argsh/libs`) instead of the project-local `.argsh/libs/`. Global installs are tracked in a separate lockfile at `${XDG_DATA_HOME:-$HOME/.local/share}/argsh/libs/.argsh-global.lock`.
 
 ```bash
 argsh add --global jaml

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -67,7 +67,7 @@ argsh search jaml     # filter by name substring
 
 ### `argsh add --global`
 
-Installs a plugin to the global libs directory (`${XDG_DATA_HOME:-~/.local/share}/argsh/libs`) instead of the project-local `.argsh/libs/`. Global installs are tracked in a separate lockfile at `~/.local/share/argsh/libs/.argsh-global.lock`.
+Installs a plugin to the global libs directory (`${XDG_DATA_HOME:-~/.local/share}/argsh/libs`) instead of the project-local `.argsh/libs/`. Global installs are tracked in a separate lockfile at `${XDG_DATA_HOME:-~/.local/share}/argsh/libs/.argsh-global.lock`.
 
 ```bash
 argsh add --global jaml
@@ -75,7 +75,7 @@ argsh add --global jaml
 
 ### `argsh install`
 
-Installs all libraries from the lockfile (`.argsh.lock`). Each entry's OCI digest is verified during install — if a digest mismatch is detected, installation of that library fails. If no lockfile exists, falls back to reading `.argsh.yaml`.
+Installs all libraries from the lockfile (`.argsh.lock`). When using the OCI pull path (Rust builtin), each entry's digest is verified — mismatches fail the install. The curl fallback path warns but cannot verify digests. If no lockfile exists, falls back to reading `.argsh.yaml`.
 
 ```bash
 argsh install


### PR DESCRIPTION
## Summary
Update documentation to reflect all features shipped in PRs #135-#162:

- **Plugin overview**: Top-level commands (`argsh add` not `argsh lib add`), search, global installs, digest verification
- **Plugin authoring**: `depends:` list, `requires.argsh` constraint, publish validation
- **Environment variables**: `ARGSH_OCI_CONNECT_TIMEOUT`, `ARGSH_OCI_IO_TIMEOUT`
- **Lint docs**: `-W`/`--wiki-link-count` flag documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)