### PR TITLE
fix(ci): move regeneration into release PR

### DIFF
--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -525,45 +525,6 @@ jobs:
           name: vsix-${{ matrix.platform }}
           path: argsh-${{ matrix.platform }}.vsix
 
-  # ---------------------------------------------------------------------------
-  # Regenerate — auto-commit coverage + minified files on main.
-  # Keeps generated files in sync without requiring feature branches to
-  # commit them (which causes merge conflicts).
-  # ---------------------------------------------------------------------------
-  regenerate:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [test, lint, coverage, minify]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Direnv
-        uses: HatsuneMiku3939/direnv-action@v1
-      - name: Regenerate coverage + minified
-        run: |
-          argsh coverage builtin
-          argsh coverage minifier
-          argsh coverage shdoc
-          argsh coverage lsp
-          argsh minify
-        env:
-          GIT_COMMIT_SHA: ${{ github.sha }}
-          GIT_VERSION: ${{ github.ref_name }}
-      - name: Commit if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add argsh.min.sh builtin/coverage.json minifier/coverage.json \
-                  shdoc/coverage.json crates/argsh-lsp/coverage.json
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: regenerate coverage + minified files [skip ci]"
-            git push
-          fi
-
   release:
     runs-on: ubuntu-latest
     permissions:
@@ -575,6 +536,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
+      - name: Direnv
+        uses: HatsuneMiku3939/direnv-action@v1
       - name: Download argsh script
         uses: actions/download-artifact@v8
         with:
@@ -657,6 +620,21 @@ jobs:
 
           cp artifacts/argsh.min.sh argsh.min.sh
           git add argsh.min.sh
+      - name: Regenerate coverage files
+        run: |
+          argsh coverage builtin
+          argsh coverage minifier
+          argsh coverage shdoc
+          argsh coverage lsp
+          git add builtin/coverage.json minifier/coverage.json \
+                  shdoc/coverage.json crates/argsh-lsp/coverage.json
+      - name: Create release PR
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="Release ${TAG_NAME}"
+          branch="release-${TAG_NAME}"
           git diff --cached --quiet || git commit -m "${title}"
           git push --force origin "HEAD:refs/heads/${branch}"
           gh pr create --title "${title}" --body "" --head "${branch}" 2>/dev/null \


### PR DESCRIPTION
## Summary
- Remove `regenerate` job that pushed directly to main (blocked by branch protection)
- Add coverage regeneration step to the `release` job
- Generated files (coverage.json, argsh.min.sh) are now included in the release PR

## Before
Tag push → regenerate job → push to main (❌ blocked by branch protection)

## After  
Tag push → release job → creates PR with minified + coverage files → merge via PR ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)