### PR TITLE
fix(ci): install libgcc-s1 for coverage-instrumented .so

### DIFF
--- a/.github/workflows/argsh.yaml
+++ b/.github/workflows/argsh.yaml
@@ -182,6 +182,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Direnv
         uses: HatsuneMiku3939/direnv-action@v1
+      - name: Install runtime deps for coverage-instrumented .so
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libgcc-s1
       - name: Builtin coverage
         run: argsh coverage builtin
       - name: Minifier coverage


### PR DESCRIPTION
## Summary
Coverage-instrumented .so uses `panic=unwind` which needs `libgcc_s.so.1`. Add `apt-get install libgcc-s1` before running builtin coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)